### PR TITLE
Makefile changes: .SILENT & .PHONY targets, pkg-config with the shell cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
-#CFLAGS = `pkg-config --cflags --libs openssl` -lportaudio
-CFLAGS = `pkg-config --cflags --libs openssl ao`
+PKGFLAGS:=$(shell pkg-config --cflags --libs openssl ao)
+CFLAGS:=-D__i386 -O2
+LDFLAGS:=-lm -lpthread
+PAUFLAGS:=-lportaudio
+
+all: hairtunes
 
 hairtunes: hairtunes.c alac.c
-	gcc hairtunes.c alac.c -D__i386 -lm $(CFLAGS) -o hairtunes
+	$(CC) $(CFLAGS) $(PKGFLAGS) $(LDFLAGS) $? -o $@
+
+clean:
+	-@rm -rf hairtunes
+
+.PTHONY: all clean
+
+.SILENT: clean
+


### PR DESCRIPTION
Hello, Albert. 
only makefile is changed for now. 

Makefile changes: .SILENT & .PHONY targets, pkg-config with the shell cmd.

New targets: .SILENT, .PHONY, clean. CC & other vars were defined.
-lportaudio is preserved but unused for now.
