### PR TITLE
Disable compile time optimisation -O2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKGFLAGS:=$(shell pkg-config --cflags --libs openssl ao)
-CFLAGS:=-O2
+CFLAGS:=-O0
 LDFLAGS:=-lm -lpthread
 PAUFLAGS:=-lportaudio
 


### PR DESCRIPTION
via Martin Spasov: -O2 Causes just noise, when playing on my debian box. Compiled with gcc (Debian 4.4.5-8) 4.4.5
https://github.com/mspasov/shairport/commit/a4e0a53d9d7f996dc26d37371c36537cfd54916c
