### PR TITLE
Output to named pipe, as well as "ao" and "PortAudio"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,10 @@
 Type `make` to build the packet decoder, `hairtunes`.
 
+The default output destination is libAO. Alternative destinations are PortAudio and named pipe. For those, type:
+
+ * make OUTPUT=-DOUTPUT_PORTAUDIO or
+ * make OUTPUT=-DOUTPUT_PIPE
+
 You need the following installed:
 
  * openssl

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ CFLAGS:=-O2 -Wall
 LDFLAGS:=-lm -lpthread
 PAUFLAGS:=-lportaudio
 
+OUTPUT:=
+
 all: hairtunes
 
 hairtunes: hairtunes.c alac.c
-	$(CC) $(CFLAGS) hairtunes.c alac.c -o $@ $(PKGFLAGS) $(LDFLAGS)
+	$(CC) $(OUTPUT) $(CFLAGS) hairtunes.c alac.c -o $@ $(PKGFLAGS) $(LDFLAGS)
 
 clean:
 	-@rm -rf hairtunes


### PR DESCRIPTION
I needed to change the output to go to a named pipe, rather than to libAO.

The code appears to be functional - it works well enough for me - but it's probably obvious that I'm neither a C nor Makefile expert. So I'm happy to accept comments and suggestions before resubmitting a further pull request :)

[apologies for the previous pull request - I'd made changes on my master branch, and I understand that a topic branch is the recommended way]
