### PR TITLE
pipe output: now handles SIGPIPE when readers stop reading

### DIFF
--- a/hairtunes.c
+++ b/hairtunes.c
@@ -705,8 +705,8 @@ void *audio_thread_func(void *arg) {
 
         if (pipename) {
             if (pipe_handle == -1) {
-                // attempt to open pipe, don't block
-                pipe_handle = open(pipename, O_WRONLY | O_NDELAY);
+                // attempt to open pipe - block if there are no readers
+                pipe_handle = open(pipename, O_WRONLY);
             }
 
             // only write if pipe open (there's a reader)


### PR DESCRIPTION
Better handling of reader connections/disconnections:
- SIGPIPE now handled - closes file
- file re-opened when another reader starts reading

Some extra tabs were converted to spaces in this commit... let me know if this is a problem. Are there any rules about tabs/spaces?
