### PR TITLE
Fixed up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
-PKGFLAGS:=$(shell pkg-config --cflags --libs openssl ao)
-CFLAGS:=-O2 -Wall
-LDFLAGS:=-lm -lpthread
-
+CFLAGS:=-O2 -Wall $(shell pkg-config --cflags openssl ao)
+LDFLAGS:=-lm -lpthread $(shell pkg-config --libs openssl ao)
+OBJS=socketlib.o shairport.o alac.o hairtunes.o
 all: hairtunes shairport
 
-hairtunes: hairtunes.c alac.c
-	$(CC) $(CFLAGS) hairtunes.c alac.c -o $@ $(PKGFLAGS) $(LDFLAGS)
+hairtunes: hairtunes.c alac.o
+	$(CC) $(CFLAGS) -DHAIRTUNES_STANDALONE hairtunes.c alac.c -o $@ $(LDFLAGS)
 
-shairport: socketlib.c shairport.c alac.c
-	$(CC) $(CFLAGS) alac.c socketlib.c shairport.c -o $@ $(PKGFLAGS) $(LDFLAGS)
+shairport: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
 
 clean:
-	-@rm -rf hairtunes shairport
+	-@rm -rf hairtunes shairport $(OBJS)
+
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
 
 prefix=/usr/local
 install: hairtunes

--- a/hairtunes.c
+++ b/hairtunes.c
@@ -235,7 +235,7 @@ int hairtunes_init(char *pAeskey, char *pAesiv, char *fmtpstr, int pCtrlPort, in
     return EXIT_SUCCESS;
 }
 
-#ifndef DONT_USE_HAIRTUNES_MAIN
+#ifdef HAIRTUNES_STANDALONE
 int main(int argc, char **argv) {
     char *hexaeskey = 0, *hexaesiv = 0;
     char *fmtpstr = 0;

--- a/shairport.c
+++ b/shairport.c
@@ -27,9 +27,7 @@
 #include <fcntl.h>
 #include "socketlib.h"
 #include "shairport.h"
-
-#define DONT_USE_HAIRTUNES_MAIN
-#include "hairtunes.c" // couldn't figure out how to allow both mains.
+#include "hairtunes.h"
 
 #ifndef TRUE
 #define TRUE (-1)


### PR DESCRIPTION
Altered Makefile to build separate object files. Very useful when native compiling on slow embedded devices. Removed the need to include the hairtunes.c file.
