### PR TITLE
Fallback to IPv4 if IPv6 is not present

### DIFF
--- a/socketlib.c
+++ b/socketlib.c
@@ -31,6 +31,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
@@ -43,7 +44,15 @@ int common_setup(struct addrinfo *pAddrInfo)
   int tSock;
   //printAddrs(pAddrInfo);
   tSock = socket(pAddrInfo->ai_family, pAddrInfo->ai_socktype, 0);
-
+#ifdef AF_INET6
+  if((tSock==-1) && (pAddrInfo->ai_family == AF_INET6) && (errno == EAFNOSUPPORT))
+  {
+    //Fallback to ipv4
+    perror("Failed to create ipv6 socket. Trying ipv4");
+    pAddrInfo->ai_family = AF_INET;
+    tSock = socket(pAddrInfo->ai_family, pAddrInfo->ai_socktype, 0);
+  }
+#endif
   return tSock;
 }
 


### PR DESCRIPTION
This fixes systems where IPv6 is available in libraries but just not enabled
in the kernel.
