### PR TITLE
Support older versions of libao

### DIFF
--- a/hairtunes.c
+++ b/hairtunes.c
@@ -823,6 +823,9 @@ void* init_ao() {
         ao_append_option(&ao_opts, "id", libao_deviceid);
     } else if(libao_devicename){
         ao_append_option(&ao_opts, "dev", libao_devicename);
+        // Old libao versions (for example, 0.8.8) only support
+        // "dsp" instead of "dev".
+        ao_append_option(&ao_opts, "dsp", libao_devicename);
     }
 
     ao_device *dev = ao_open_live(driver, &fmt, ao_opts);


### PR DESCRIPTION
My Synology NAS has 0.8.8 available via ipkg/optware, but it doesn't respond to the "dev" option. "dsp", which is deprecated according to the documentation, works.

Since libao seems to be ignoring invalid options, simply setting both values seems like a reasonable thing to do.
