### PR TITLE
Configurable start buffer size

### DIFF
--- a/hairtunes.c
+++ b/hairtunes.c
@@ -52,11 +52,8 @@ int debug = 0;
 
 #include "alac.h"
 
-// default buffer size
-#define BUFFER_FRAMES  320
 // and how full it needs to be to begin (must be <BUFFER_FRAMES)
 #define START_FILL    282
-
 
 #define MAX_PACKET      2048
 
@@ -70,6 +67,8 @@ int dataport = 0, controlport = 0, timingport = 0;
 int fmtp[32];
 int sampling_rate;
 int frame_size;
+
+int buffer_start_fill = START_FILL;
 
 char *libao_driver = NULL;
 char *libao_devicename = NULL;
@@ -386,7 +385,7 @@ void buffer_put_packet(seq_t seqno, char *data, int len) {
         abuf->ready = 1;
     }
 
-    if (ab_buffering && buf_fill >= START_FILL) {
+    if (ab_buffering && buf_fill >= buffer_start_fill) {
         ab_buffering = 0;
         pthread_cond_signal(&ab_buffer_ready);
     }

--- a/hairtunes.h
+++ b/hairtunes.h
@@ -2,4 +2,8 @@
 #define _HAIRTUNES_H_
 int hairtunes_init(char *pAeskey, char *pAesiv, char *pFmtpstr, int pCtrlPort, int pTimingPort,
          int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId);
+
+// default buffer size
+#define BUFFER_FRAMES  320
+
 #endif 

--- a/shairport.c
+++ b/shairport.c
@@ -39,6 +39,7 @@
 // TEMP
 
 int kCurrentLogLevel = LOG_INFO;
+extern int buffer_start_fill;
 
 #ifdef _WIN32
 #define DEVNULL "nul"
@@ -94,6 +95,15 @@ int main(int argc, char **argv)
     {
       tPort = atoi(arg+14);
     }
+    else if(!strcmp(arg, "-b")) 
+    {
+      buffer_start_fill = atoi(*++argv);
+      argc--;
+    }
+    else if(!strncmp(arg, "--buffer=", 9))
+    {
+      buffer_start_fill = atoi(arg + 9);
+    }
     else if(!strcmp(arg, "-k"))
     {
       tUseKnownHWID = TRUE;
@@ -126,12 +136,18 @@ int main(int argc, char **argv)
       slog(LOG_INFO, "  -a, --apname=AirPort    Sets Airport name\n");
       slog(LOG_INFO, "  -p, --password=secret   Sets Password (not working)\n");
       slog(LOG_INFO, "  -o, --server_port=5000  Sets Port for Avahi/dns-sd\n");
+      slog(LOG_INFO, "  -b, --buffer=282        Sets Number of frames to buffer before beginning playback\n");
       slog(LOG_INFO, "  -d                      Daemon mode\n");
       slog(LOG_INFO, "  -q, --quiet             Supresses all output.\n");
       slog(LOG_INFO, "  -v,-v2,-v3,-vv          Various debugging levels\n");
       slog(LOG_INFO, "\n");
       return 0;
     }    
+  }
+
+  if ( buffer_start_fill < 30 || buffer_start_fill > BUFFER_FRAMES ) { 
+     fprintf(stderr, "buffer value must be > 30 and < %d\n", BUFFER_FRAMES);
+     return(0);
   }
 
   if(tDaemonize)


### PR DESCRIPTION
The default START_FILL of 282, while perhaps in sync with the airport express, makes initial playback and flipping through songs a bit slow for me.  This patch adds a configurable start-buffer size to the standalone shairport -- note that it's not done for the perl version, as I'm not quite familiar with that code. 
