### PR TITLE
avoid many tons of retries

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
       dup(tIdx);
     }
   }
-  srand ( time(NULL) );
+  srandom ( time(NULL) );
   // Copy over empty 00's
   //tPrintHWID[tIdx] = tAddr[0];
 
@@ -1004,15 +1004,15 @@ char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDes
 
 void slog(int pLevel, char *pFormat, ...)
 {
-  #ifdef SHAIRPORT_LOG
-  if(isLogEnabledFor(pLevel))
+  //#ifdef SHAIRPORT_LOG
+  //if(isLogEnabledFor(pLevel))
   {
     va_list argp;
     va_start(argp, pFormat);
     vprintf(pFormat, argp);
     va_end(argp);
   }
-  #endif
+  //#endif
 }
 
 int isLogEnabledFor(int pLevel)

--- a/shairport.c
+++ b/shairport.c
@@ -353,7 +353,7 @@ void handleClient(int pSock, char *pPassword, char *pHWADDR)
     while(1 == tMoreDataNeeded)
     {
       tError = readDataFromClient(pSock, &(tConn.recv));
-      if(!tError)
+      if(!tError && strlen(tConn.recv.data) > 0)
       {
         slog(LOG_DEBUG_VV, "Finished Reading some data from client\n");
         // parse client request

--- a/shairport.h
+++ b/shairport.h
@@ -66,7 +66,7 @@ void addToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf);
 void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf);
 
 int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer);
-int  parseMessage(struct connection *pConn, char *pIpStr, char *pHWADDR);
+int  parseMessage(struct connection *pConn,unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWADDR);
 
 void closePipe(int *pPipe);
 void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp);
@@ -75,8 +75,7 @@ void initConnection(struct connection *pConn, struct keyring *pKeys,
 
 void writeDataToClient(int pSock, struct shairbuffer *pResponse);
 void propogateCSeq(struct connection *pConn);
-void convertIpToBinary(char *pIpAddress, int pIsIPv6, char *pBinaryOutput);
-int buildAppleResponse(struct connection *pConn, char *pIpStr, char *pHwAddr);
+int buildAppleResponse(struct connection *pConn, unsigned char *pIpBin, unsigned int pIpBinLen, char *pHwAddr);
 void sim(int pLevel, char *pValue1, char *pValue2);
 void slog(int pLevel, char *pFormat, ...);
 int  isLogEnabledFor(int pLevel);


### PR DESCRIPTION
sometime, usually due to a bug, the client decides to close the connection. the read() returns 0 (which means end-of-file), but the code still continues to parse nothing. Change the code so that it parses only if there's something to parse.
