### PR TITLE
Install documentation fix for recent Debian/Ubuntu releases.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
 
 ## Debian/Ubuntu:
 
-    apt-get install libssl-dev libcrypt-openssl-rsa-perl libao2 libao-dev libio-socket-inet6-perl libwww-perl avahi-utils pkg-config
+    apt-get install libssl-dev libcrypt-openssl-rsa-perl libao-dev libio-socket-inet6-perl libwww-perl avahi-utils pkg-config
     make
     perl shairport.pl
 


### PR DESCRIPTION
Removed libao2 package from Debian/Ubuntu package install list since the package name varies on different releases. (E.g. it's libao2 on Lenny and Dapper Drake, but liba04 on Squeeze and Natty Narwhal.) I couldn't install on Natty because "Package labao2 is not available".

The proper version will always be installed because libao-dev depends on it.
