### PR TITLE
1 x bugfix, 1 x improvement, 1 x new feature

### DIFF
--- a/hairtunes.c
+++ b/hairtunes.c
@@ -393,8 +393,10 @@ void buffer_put_packet(seq_t seqno, char *data, int len) {
         // check if the t+10th packet has arrived... last-chance resend
         read = ab_read + 10;
         abuf = audio_buffer + BUFIDX(read);
-        if (!abuf->ready)
+        if (abuf->ready != 1) {
             rtp_request_resend(read, read);
+            abuf->ready = -1;
+        }
     }
 }
 
@@ -671,7 +673,7 @@ short *buffer_get_frame(void) {
     bf_est_update(buf_fill);
 
     volatile abuf_t *curframe = audio_buffer + BUFIDX(read);
-    if (!curframe->ready) {
+    if (curframe->ready != 1) {
         fprintf(stderr, "\nmissing frame.\n");
         memset(curframe->data, 0, FRAME_BYTES);
     }

--- a/hairtunes.h
+++ b/hairtunes.h
@@ -4,6 +4,7 @@ int hairtunes_init(char *pAeskey, char *pAesiv, char *pFmtpstr, int pCtrlPort, i
          int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId);
 
 // default buffer size
-#define BUFFER_FRAMES  320
+// needs to be a power of 2 because of the way BUFIDX(seqno) works
+#define BUFFER_FRAMES  512
 
 #endif 

--- a/shairport.pl
+++ b/shairport.pl
@@ -71,6 +71,9 @@ my $cliport;
 my $mac;
 # SB volume
 my $volume;
+# custom play and stop program
+my $play_prog;
+my $stop_prog;
 # output debugging information
 my $verbose;
 # where to write PID
@@ -97,6 +100,8 @@ GetOptions("a|apname=s" => \$apname,
           "s|squeezebox" => \$squeeze,
           "c|cliport=s" => \$cliport,
           "m|mac=s" => \$mac,
+          "play_prog=s" => \$play_prog,
+          "stop_prog=s" => \$stop_prog,
           "l|volume=s" => \$volume,
           "h|help" => \$help);
 
@@ -117,6 +122,8 @@ sub usage {
           "  -c  --cliport=port              Sets the SBS CLI port\n",
           "  -m  --mac=address               Sets the SB target device\n",
           "  -l  --volume=level              Sets the SB volume level (in %)\n",
+          "      --play_prog=cmdline         Program to start on 1st connection\n",
+          "      --stop_prog=cmdline         Program to start on last disconnection\n",
           "  -d                              Daemon mode\n",
           "  -w  --writepid=path             Write PID to this location\n",
           "  -v  --verbose                   Print debugging messages\n",
@@ -491,6 +498,11 @@ while (1) {
             if (defined($squeeze) && $squeeze) {
                 &performSqueezeboxSetup();
             }
+
+            # the 2nd connection is a player connection
+            if (defined($play_prog) && $sel->count() == 2) {
+                system($play_prog);
+            }
         } else {
             if (eof($fh)) {
                 print "Closed: $fh\n" if $verbose;
@@ -502,6 +514,11 @@ while (1) {
                     eval { kill $conns{$fh}{decoder_pid} };
                 }
                 delete $conns{$fh};
+
+                # 1 connection means no connection
+                if (defined($stop_prog) && $sel->count() == 1) {
+                    system($stop_prog);
+                }
                 next;
             }
             if (exists $conns{$fh}) {


### PR DESCRIPTION
As requested, I made the previously-initiated issues pull requests.
- BUFFER_FRAMES should be a power of two (currently it's 320, which gives garbled sound every time the sequence number wraps, this is due to the current implementation of BUFIDX)
- send last-chance-retry only once (currently, I saw  up to 6 retries for the same packet fired in the same second)
- new feature: run a custom program on first connect play and and last disconnect.

Feel free to further improve any of these changes.
