### PR TITLE
Fix compilation error

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,12 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
     make
     perl shairport.pl
 
+## OpenBSD
+
+    pkg_add -r gmake libao avahi p5-libwww p5-Crypt-OpenSSL-RSA p5-IO-Socket-INET6
+    gmake
+    perl shairport.pl
+
 ## Mac OS X:
 
   * install XCode

--- a/shairport.h
+++ b/shairport.h
@@ -10,6 +10,7 @@
 #include "socketlib.h"
 #include <regex.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <regex.h>
 
 


### PR DESCRIPTION
When I tried to compile shairport at Gentoo/ppc and OpenBSD/i386, I got the following error:

```
shairport.c:57: error: 'WNOHANG' undeclared (first use in this function)
shairport.c:57: error: (Each undeclared identifier is reported only once
shairport.c:57: error: for each function it appears in.)
```

In addition, a synopsis of the waitpid(2) on these systems begins with the following lines:

```
#include <sys/types.h>
#include <sys/wait.h>
```
