### PR TITLE
Cleanup, optimization, and bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OBJS=socketlib.o shairport.o alac.o hairtunes.o
 all: hairtunes shairport
 
 hairtunes: hairtunes.c alac.o
-	$(CC) $(CFLAGS) -DHAIRTUNES_STANDALONE hairtunes.c alac.c -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) -DHAIRTUNES_STANDALONE hairtunes.c alac.o -o $@ $(LDFLAGS)
 
 shairport: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install: hairtunes shairport
 	install -D -m 0755 shairport.pl $(DESTDIR)$(prefix)/bin/shairport.pl
 	install -D -m 0755 shairport $(DESTDIR)$(prefix)/bin/shairport
 
-.PTHONY: all clean install
+.PHONY: all clean install
 
 .SILENT: clean
 

--- a/alac.c
+++ b/alac.c
@@ -109,7 +109,6 @@ void alac_set_info(alac_file *alac, char *inputbuffer)
   alac->setinfo_8a_rate = *(uint32_t*)ptr;
   if (!host_bigendian)
       _Swap32(alac->setinfo_8a_rate);
-  ptr += 4;
 
   allocate_buffers(alac);
 

--- a/alac.c
+++ b/alac.c
@@ -289,7 +289,7 @@ found:
 
 #define RICE_THRESHOLD 8 // maximum number of bits for a rice prefix.
 
-int32_t entropy_decode_value(alac_file* alac,
+static int32_t entropy_decode_value(alac_file* alac,
                              int readSampleSize,
                              int k,
                              int rice_kmodifier_mask)
@@ -333,7 +333,7 @@ int32_t entropy_decode_value(alac_file* alac,
     return x;
 }
 
-void entropy_rice_decode(alac_file* alac,
+static void entropy_rice_decode(alac_file* alac,
                          int32_t* outputBuffer,
                          int outputSize,
                          int readSampleSize,
@@ -550,7 +550,7 @@ static void predictor_decompress_fir_adapt(int32_t *error_buffer,
     }
 }
 
-void deinterlace_16(int32_t *buffer_a, int32_t *buffer_b,
+static void deinterlace_16(int32_t *buffer_a, int32_t *buffer_b,
                     int16_t *buffer_out,
                     int numchannels, int numsamples,
                     uint8_t interlacing_shift,
@@ -609,7 +609,7 @@ void deinterlace_16(int32_t *buffer_a, int32_t *buffer_b,
     }
 }
 
-void deinterlace_24(int32_t *buffer_a, int32_t *buffer_b,
+static void deinterlace_24(int32_t *buffer_a, int32_t *buffer_b,
                     int uncompressed_bytes,
                     int32_t *uncompressed_bytes_buffer_a, int32_t *uncompressed_bytes_buffer_b,
                     void *buffer_out,

--- a/hairtunes.c
+++ b/hairtunes.c
@@ -586,11 +586,11 @@ static void biquad_lpf(biquad_t *bq, double freq, double Q) {
 
 static double biquad_filt(biquad_t *bq, double in) {
     double w = in - bq->a[0]*bq->hist[0] - bq->a[1]*bq->hist[1];
-    double out __attribute__((unused)) = bq->b[1]*bq->hist[0] + bq->b[2]*bq->hist[1] + bq->b[0]*w;
+    double out = bq->b[1]*bq->hist[0] + bq->b[2]*bq->hist[1] + bq->b[0]*w;
     bq->hist[1] = bq->hist[0];
     bq->hist[0] = w;
 
-    return w;
+    return out;
 }
 
 static double bf_playback_rate = 1.0;

--- a/hairtunes.c
+++ b/hairtunes.c
@@ -354,7 +354,6 @@ void alac_decode(short *dest, char *buf, int len) {
 
 void buffer_put_packet(seq_t seqno, char *data, int len) {
     volatile abuf_t *abuf = 0;
-    short read;
     short buf_fill;
 
     pthread_mutex_lock(&ab_mutex);
@@ -367,7 +366,7 @@ void buffer_put_packet(seq_t seqno, char *data, int len) {
         abuf = audio_buffer + BUFIDX(seqno);
         ab_write = seqno;
     } else if (seq_order(ab_write, seqno)) {    // newer than expected
-        rtp_request_resend(ab_write, seqno-1);
+        rtp_request_resend(ab_write+1, seqno-1);
         abuf = audio_buffer + BUFIDX(seqno);
         ab_write = seqno;
     } else if (seq_order(ab_read, seqno)) {     // late but not yet played
@@ -386,15 +385,6 @@ void buffer_put_packet(seq_t seqno, char *data, int len) {
     if (ab_buffering && buf_fill >= buffer_start_fill) {
         ab_buffering = 0;
         pthread_cond_signal(&ab_buffer_ready);
-    }
-    if (!ab_buffering) {
-        // check if the t+10th packet has arrived... last-chance resend
-        read = ab_read + 10;
-        abuf = audio_buffer + BUFIDX(read);
-        if (abuf->ready != 1) {
-            rtp_request_resend(read, read);
-            abuf->ready = -1;
-        }
     }
 }
 
@@ -642,6 +632,9 @@ void bf_est_update(short fill) {
 short *buffer_get_frame(void) {
     short buf_fill;
     seq_t read;
+    volatile abuf_t *abuf = 0;
+    unsigned short next;
+    int i;
 
     pthread_mutex_lock(&ab_mutex);
 
@@ -670,8 +663,19 @@ short *buffer_get_frame(void) {
     buf_fill = ab_write - ab_read;
     bf_est_update(buf_fill);
 
+    // check if t+16, t+32, t+64, t+128, ... (START_FILL / 2)  packets have arrived... last-chance resend
+    if (!ab_buffering) {
+        for (i = 16; i < (START_FILL / 2); i = (i * 2)) {
+            next = ab_read + i;
+            abuf = audio_buffer + BUFIDX(next);
+            if (!abuf->ready) {
+                rtp_request_resend(next, next);
+            }
+        }
+    }
+
     volatile abuf_t *curframe = audio_buffer + BUFIDX(read);
-    if (curframe->ready != 1) {
+    if (!curframe->ready) {
         fprintf(stderr, "\nmissing frame.\n");
         memset(curframe->data, 0, FRAME_BYTES);
     }

--- a/hairtunes.c
+++ b/hairtunes.c
@@ -163,7 +163,8 @@ int init_decoder(void) {
 }
 
 int hairtunes_init(char *pAeskey, char *pAesiv, char *fmtpstr, int pCtrlPort, int pTimingPort,
-         int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId)
+         int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId,
+         int bufStartFill)
 {
     if(pAeskey != NULL)    
         memcpy(aeskey, pAeskey, sizeof(aeskey));
@@ -183,6 +184,9 @@ int hairtunes_init(char *pAeskey, char *pAesiv, char *fmtpstr, int pCtrlPort, in
     controlport = pCtrlPort;
     timingport = pTimingPort;
     dataport = pDataPort;
+    if(bufStartFill < 0)
+        bufStartFill = START_FILL;
+    buffer_start_fill = bufStartFill;
 
     AES_set_decrypt_key(aeskey, 128, &aes);
 
@@ -309,7 +313,7 @@ int main(int argc, char **argv) {
     if (hex2bin(aeskey, hexaeskey))
         die("can't understand key");
     return hairtunes_init(NULL, NULL, fmtpstr, controlport, timingport, dataport,
-                    NULL, NULL, NULL, NULL, NULL);
+                    NULL, NULL, NULL, NULL, NULL, START_FILL);
 }
 #endif
 
@@ -654,7 +658,7 @@ short *buffer_get_frame(void) {
     }
     if (buf_fill >= BUFFER_FRAMES) {   // overrunning! uh-oh. restart at a sane distance
         fprintf(stderr, "\noverrun.\n");
-        ab_read = ab_write - START_FILL;
+        ab_read = ab_write - buffer_start_fill;
     }
     read = ab_read;
     ab_read++;

--- a/hairtunes.h
+++ b/hairtunes.h
@@ -1,7 +1,8 @@
 #ifndef _HAIRTUNES_H_
 #define _HAIRTUNES_H_
-int hairtunes_init(char *pAeskey, char *pAesiv, char *pFmtpstr, int pCtrlPort, int pTimingPort,
-         int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId);
+int hairtunes_init(char *pAeskey, char *pAesiv, char *fmtpstr, int pCtrlPort, int pTimingPort,
+         int pDataPort, char *pRtpHost, char*pPipeName, char *pLibaoDriver, char *pLibaoDeviceName, char *pLibaoDeviceId,
+         int bufStartFill);
 
 // default buffer size
 // needs to be a power of 2 because of the way BUFIDX(seqno) works

--- a/shairport.c
+++ b/shairport.c
@@ -40,7 +40,7 @@
 // TEMP
 
 int kCurrentLogLevel = LOG_INFO;
-extern int buffer_start_fill;
+int bufferStartFill = -1;
 
 #ifdef _WIN32
 #define DEVNULL "nul"
@@ -113,12 +113,12 @@ int main(int argc, char **argv)
     }
     else if(!strcmp(arg, "-b")) 
     {
-      buffer_start_fill = atoi(*++argv);
+      bufferStartFill = atoi(*++argv);
       argc--;
     }
     else if(!strncmp(arg, "--buffer=", 9))
     {
-      buffer_start_fill = atoi(arg + 9);
+      bufferStartFill = atoi(arg + 9);
     }
     else if(!strcmp(arg, "-k"))
     {
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
     }    
   }
 
-  if ( buffer_start_fill < 30 || buffer_start_fill > BUFFER_FRAMES ) { 
+  if ( bufferStartFill < 30 || bufferStartFill > BUFFER_FRAMES ) {
      fprintf(stderr, "buffer value must be > 30 and < %d\n", BUFFER_FRAMES);
      return(0);
   }
@@ -774,7 +774,8 @@ int parseMessage(struct connection *pConn, unsigned char *pIpBin, unsigned int p
       }
       cleanupBuffers(pConn);
       hairtunes_init(tKeys->aeskey, tKeys->aesiv, tKeys->fmt, tControlport, tTimingport,
-                      tDataport, tRtp, tPipe, tAoDriver, tAoDeviceName, tAoDeviceId);
+                      tDataport, tRtp, tPipe, tAoDriver, tAoDeviceName, tAoDeviceId,
+                      bufferStartFill);
 
       // Quit when finished.
       slog(LOG_DEBUG, "Returned from hairtunes init....returning -1, should close out this whole side of the fork\n");

--- a/shairport.c
+++ b/shairport.c
@@ -52,7 +52,37 @@ int bufferStartFill = -1;
 #define HEADER_LOG_LEVEL LOG_DEBUG
 #define AVAHI_LOG_LEVEL LOG_DEBUG
 
-void handle_sigchld(int signo) {
+static void handleClient(int pSock, char *pPassword, char *pHWADDR);
+static void writeDataToClient(int pSock, struct shairbuffer *pResponse);
+static int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer);
+
+static int parseMessage(struct connection *pConn,unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWADDR);
+static void propogateCSeq(struct connection *pConn);
+
+static void cleanupBuffers(struct connection *pConnection);
+static void cleanup(struct connection *pConnection);
+
+static int startAvahi(const char *pHwAddr, const char *pServerName, int pPort);
+
+static int getAvailChars(struct shairbuffer *pBuf);
+static void addToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf);
+static void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf);
+
+static char *getTrimmedMalloc(char *pChar, int pSize, int pEndStr, int pAddNL);
+static char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDest);
+
+static void slog(int pLevel, char *pFormat, ...);
+static int isLogEnabledFor(int pLevel);
+
+static void initConnection(struct connection *pConn, struct keyring *pKeys, struct comms *pComms, int pSocket, char *pPassword);
+static void closePipe(int *pPipe);
+static void initBuffer(struct shairbuffer *pBuf, int pNumChars);
+
+static void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp);
+static RSA *loadKey(void);
+
+
+static void handle_sigchld(int signo) {
     int status;
     waitpid(-1, &status, WNOHANG);
 }
@@ -275,7 +305,7 @@ int main(int argc, char **argv)
   return 0;
 }
 
-int findEnd(char *tReadBuf)
+static int findEnd(char *tReadBuf)
 {
   // find \n\n, \r\n\r\n, or \r\r is found
   int tIdx = 0;
@@ -313,7 +343,7 @@ int findEnd(char *tReadBuf)
   return -1;
 }
 
-void handleClient(int pSock, char *pPassword, char *pHWADDR)
+static void handleClient(int pSock, char *pPassword, char *pHWADDR)
 {
   slog(LOG_DEBUG_VV, "In Handle Client\n");
   fflush(stdout);
@@ -421,15 +451,14 @@ void handleClient(int pSock, char *pPassword, char *pHWADDR)
   fflush(stdout);
 }
 
-
-void writeDataToClient(int pSock, struct shairbuffer *pResponse)
+static void writeDataToClient(int pSock, struct shairbuffer *pResponse)
 {
   slog(LOG_DEBUG_VV, "\n----Beg Send Response Header----\n%.*s\n", pResponse->current, pResponse->data);
   send(pSock, pResponse->data, pResponse->current,0);
   slog(LOG_DEBUG_VV, "----Send Response Header----\n");
 }
 
-int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer)
+static int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer)
 {
   char tReadBuf[MAX_SIZE];
   tReadBuf[0] = '\0';
@@ -481,7 +510,7 @@ int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer)
   return 0;
 }
 
-char *getFromBuffer(char *pBufferPtr, const char *pField, int pLenAfterField, int *pReturnSize, char *pDelims)
+static char *getFromBuffer(char *pBufferPtr, const char *pField, int pLenAfterField, int *pReturnSize, char *pDelims)
 {
   slog(LOG_DEBUG_V, "GettingFromBuffer: %s\n", pField);
   char* tFound = strstr(pBufferPtr, pField);
@@ -517,25 +546,25 @@ char *getFromBuffer(char *pBufferPtr, const char *pField, int pLenAfterField, in
   return tFound;
 }
 
-
-char *getFromHeader(char *pHeaderPtr, const char *pField, int *pReturnSize)
+static char *getFromHeader(char *pHeaderPtr, const char *pField, int *pReturnSize)
 {
   return getFromBuffer(pHeaderPtr, pField, 2, pReturnSize, "\r\n");
 }
 
-char *getFromContent(char *pContentPtr, const char* pField, int *pReturnSize)
+static char *getFromContent(char *pContentPtr, const char* pField, int *pReturnSize)
 {
   return getFromBuffer(pContentPtr, pField, 1, pReturnSize, "\r\n");
 }
 
-char *getFromSetup(char *pContentPtr, const char* pField, int *pReturnSize)
+static char *getFromSetup(char *pContentPtr, const char* pField, int *pReturnSize)
 {
   return getFromBuffer(pContentPtr, pField, 1, pReturnSize, ";\r\n");
 }
 
 // Handles compiling the Apple-Challenge, HWID, and Server IP Address
 // Into the response the airplay client is expecting.
-int buildAppleResponse(struct connection *pConn, unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWID)
+static int buildAppleResponse(struct connection *pConn, unsigned char *pIpBin,
+                              unsigned int pIpBinLen, char *pHWID)
 {
   // Find Apple-Challenge
   char *tResponse = NULL;
@@ -604,7 +633,7 @@ int buildAppleResponse(struct connection *pConn, unsigned char *pIpBin, unsigned
 }
 
 //parseMessage(tConn->recv.data, tConn->recv.mark, &tConn->resp, ipstr, pHWADDR, tConn->keys);
-int parseMessage(struct connection *pConn, unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWID)
+static int parseMessage(struct connection *pConn, unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWID)
 {
   int tReturn = 0; // 0 = good, 1 = Needs More Data, -1 = close client socket.
   if(pConn->resp.data == NULL)
@@ -860,7 +889,7 @@ int parseMessage(struct connection *pConn, unsigned char *pIpBin, unsigned int p
 }
 
 // Copies CSeq value from request, and adds standard header values in.
-void propogateCSeq(struct connection *pConn) //char *pRecvBuffer, struct shairbuffer *pConn->recp.data)
+static void propogateCSeq(struct connection *pConn) //char *pRecvBuffer, struct shairbuffer *pConn->recp.data)
 {
   int tSize=0;
   char *tRecPtr = getFromHeader(pConn->recv.data, "CSeq", &tSize);
@@ -884,7 +913,7 @@ void cleanupBuffers(struct connection *pConn)
   }
 }
 
-void cleanup(struct connection *pConn)
+static void cleanup(struct connection *pConn)
 {
   cleanupBuffers(pConn);
   if(pConn->hairtunes != NULL)
@@ -918,7 +947,7 @@ void cleanup(struct connection *pConn)
   }
 }
 
-int startAvahi(const char *pHWStr, const char *pServerName, int pPort)
+static int startAvahi(const char *pHWStr, const char *pServerName, int pPort)
 {
   int tMaxServerName = 25; // Something reasonable?  iPad showed 21, iphone 25
   int tPid = fork();
@@ -960,22 +989,17 @@ int startAvahi(const char *pHWStr, const char *pServerName, int pPort)
   return tPid;
 }
 
-void printBufferInfo(struct shairbuffer *pBuf, int pLevel)
-{
-  slog(pLevel, "Buffer: [%s]  size: %d  maxchars:%d\n", pBuf->data, pBuf->current, pBuf->maxsize/sizeof(char));
-}
-
-int getAvailChars(struct shairbuffer *pBuf)
+static int getAvailChars(struct shairbuffer *pBuf)
 {
   return (pBuf->maxsize / sizeof(char)) - pBuf->current;
 }
 
-void addToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf)
+static void addToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf)
 {
   addNToShairBuffer(pBuf, pNewBuf, strlen(pNewBuf));
 }
 
-void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf)
+static void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf)
 {
   int tAvailChars = getAvailChars(pBuf);
   if(pNofNewBuf > tAvailChars)
@@ -999,7 +1023,7 @@ void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf)
   }
 }
 
-char *getTrimmedMalloc(char *pChar, int pSize, int pEndStr, int pAddNL)
+static char *getTrimmedMalloc(char *pChar, int pSize, int pEndStr, int pAddNL)
 {
   int tAdditionalSize = 0;
   if(pEndStr)
@@ -1011,7 +1035,7 @@ char *getTrimmedMalloc(char *pChar, int pSize, int pEndStr, int pAddNL)
 }
 
 // Must free returned ptr
-char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDest)
+static char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDest)
 {
   int tSize = pSize;
   if(pEndStr)
@@ -1036,7 +1060,7 @@ char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDes
   return pTrimDest;
 }
 
-void slog(int pLevel, char *pFormat, ...)
+static void slog(int pLevel, char *pFormat, ...)
 {
   #ifdef SHAIRPORT_LOG
   if(isLogEnabledFor(pLevel))
@@ -1049,7 +1073,7 @@ void slog(int pLevel, char *pFormat, ...)
   #endif
 }
 
-int isLogEnabledFor(int pLevel)
+static int isLogEnabledFor(int pLevel)
 {
   if(pLevel <= kCurrentLogLevel)
   {
@@ -1058,7 +1082,7 @@ int isLogEnabledFor(int pLevel)
   return FALSE;
 }
 
-void initConnection(struct connection *pConn, struct keyring *pKeys, 
+static void initConnection(struct connection *pConn, struct keyring *pKeys,
                     struct comms *pComms, int pSocket, char *pPassword)
 {
   pConn->hairtunes = pComms;
@@ -1082,7 +1106,7 @@ void initConnection(struct connection *pConn, struct keyring *pKeys,
   }
 }
 
-void closePipe(int *pPipe)
+static void closePipe(int *pPipe)
 {
   if(*pPipe != -1)
   {
@@ -1091,7 +1115,7 @@ void closePipe(int *pPipe)
   }
 }
 
-void initBuffer(struct shairbuffer *pBuf, int pNumChars)
+static void initBuffer(struct shairbuffer *pBuf, int pNumChars)
 {
   if(pBuf->data != NULL)
   {
@@ -1106,7 +1130,7 @@ void initBuffer(struct shairbuffer *pBuf, int pNumChars)
   memset(pBuf->data, 0, pBuf->maxsize);
 }
 
-void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp)
+static void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp)
 {
   if(pKeys->aesiv != NULL)
   {
@@ -1150,7 +1174,7 @@ void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp)
 "2gG0N5hvJpzwwhbhXqFKA4zaaSrw622wDniAK5MlIE0tIAKKP4yxNGjoD2QYjhBGuhvkWKY=\n" \
 "-----END RSA PRIVATE KEY-----"
 
-RSA *loadKey()
+static RSA *loadKey(void)
 {
   BIO *tBio = BIO_new_mem_buf(AIRPORT_PRIVATE_KEY, -1);
   RSA *rsa = PEM_read_bio_RSAPrivateKey(tBio, NULL, NULL, NULL); //NULL, NULL, NULL);

--- a/shairport.c
+++ b/shairport.c
@@ -376,13 +376,13 @@ static void handleClient(int pSock, char *pPassword, char *pHWADDR)
       port = ntohs(s->sin6_port);
       inet_ntop(AF_INET6, &s->sin6_addr, ipstr, sizeof ipstr);
 
-	  union {
-		  struct sockaddr_in6 s;
-		  unsigned char bin[sizeof(struct sockaddr_in6)];
-	  } addr;
-	  memcpy(&addr.s, &s->sin6_addr, sizeof(struct sockaddr_in6));
-	  
-	  if(memcmp(&addr.bin[0], "\x00\x00\x00\x00" "\x00\x00\x00\x00" "\x00\x00\xff\xff", 12) == 0)
+      union {
+          struct sockaddr_in6 s;
+          unsigned char bin[sizeof(struct sockaddr_in6)];
+      } addr;
+      memcpy(&addr.s, &s->sin6_addr, sizeof(struct sockaddr_in6));
+
+      if(memcmp(&addr.bin[0], "\x00\x00\x00\x00" "\x00\x00\x00\x00" "\x00\x00\xff\xff", 12) == 0)
       {
         // its ipv4...
         memcpy(ipbin, &addr.bin[12], 4);

--- a/shairport.h
+++ b/shairport.h
@@ -52,33 +52,6 @@ struct connection
   char                *password;
 };
 
-RSA *loadKey();
-int startAvahi(const char *pHwAddr, const char *pServerName, int pPort);
-void cleanupBuffers(struct connection *pConnection);
-void cleanup(struct connection *pConnection);
-void handleClient(int pSock, char *pPassword, char *pHWADDR);
-int getAvailChars(struct shairbuffer *pBuf);
-
-char *getTrimmedMalloc(char *pChar, int pSize, int pEndStr, int pAddNL);
-char *getTrimmed(char *pChar, int pSize, int pEndStr, int pAddNL, char *pTrimDest);
-void initBuffer(struct shairbuffer *pBuf, int pNumChars);
-void printBufferInfo(struct shairbuffer *pBuf, int pLevel);
-void addToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf);
-void addNToShairBuffer(struct shairbuffer *pBuf, char *pNewBuf, int pNofNewBuf);
-
-int readDataFromClient(int pSock, struct shairbuffer *pClientBuffer);
-int  parseMessage(struct connection *pConn,unsigned char *pIpBin, unsigned int pIpBinLen, char *pHWADDR);
-
-void closePipe(int *pPipe);
-void setKeys(struct keyring *pKeys, char *pIV, char* pAESKey, char *pFmtp);
-void initConnection(struct connection *pConn, struct keyring *pKeys, 
-                struct comms *pComms, int pSocket, char *pPassword);
-
-void writeDataToClient(int pSock, struct shairbuffer *pResponse);
-void propogateCSeq(struct connection *pConn);
-int buildAppleResponse(struct connection *pConn, unsigned char *pIpBin, unsigned int pIpBinLen, char *pHwAddr);
 void sim(int pLevel, char *pValue1, char *pValue2);
-void slog(int pLevel, char *pFormat, ...);
-int  isLogEnabledFor(int pLevel);
 
 #endif

--- a/socketlib.c
+++ b/socketlib.c
@@ -183,7 +183,7 @@ void delay(long pMillisecs, struct timeval *pRes)
   select(0,NULL,NULL,NULL,pRes);
 }
 
-int getCorrectedEncodeSize(int pSize)
+static int getCorrectedEncodeSize(int pSize)
 {
   if(pSize % 4 == 0)
   {
@@ -264,7 +264,7 @@ char *encode_base64(unsigned char *input, int length)
   b64 = BIO_push(b64, bmem);
 
   BIO_write(b64, input, length);
-  BIO_flush(b64);
+  (void)BIO_flush(b64);
   BIO_get_mem_ptr(b64, &bptr);
 
   char *buff = (char *)malloc(bptr->length);


### PR DESCRIPTION
The main big points here:
- Use mutexes correctly so we don't have to use volatile
- Use the 'static' keyword where appropriate so the compiler can inline and optimize as it sees fit
- Fix a rather large issue in the playback rate and drift calculation

This also includes the one commit from Stef's outstanding pull request.

https://github.com/albertz/shairport/pull/131
