### PR TITLE
Add support for mDNSPublish, from the howl zeroconf implementation.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ You need the following installed:
  * openssl
  * libao
  * Perl 5.10 or higher
- * Linux: avahi
+ * Linux: avahi (or, for embedded systems, howl)
  * Windows/Mac OS X: Bonjour
 
 Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):

--- a/shairport.c
+++ b/shairport.c
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
       slog(LOG_INFO, "Usage:\nshairport [OPTION...]\n\nOptions:\n");
       slog(LOG_INFO, "  -a, --apname=AirPort    Sets Airport name\n");
       slog(LOG_INFO, "  -p, --password=secret   Sets Password (not working)\n");
-      slog(LOG_INFO, "  -o, --server_port=5002  Sets Port for Avahi/dns-sd\n");
+      slog(LOG_INFO, "  -o, --server_port=5002  Sets Port for Avahi/dns-sd/howl\n");
       slog(LOG_INFO, "  -b, --buffer=282        Sets Number of frames to buffer before beginning playback\n");
       slog(LOG_INFO, "  -d                      Daemon mode\n");
       slog(LOG_INFO, "  -q, --quiet             Supresses all output.\n");
@@ -975,11 +975,14 @@ static int startAvahi(const char *pHWStr, const char *pServerName, int pPort)
     execlp("dns-sd", "dns-sd", "-R", tName,
          "_raop._tcp", ".", tPort, "tp=UDP","sm=false","sv=false","ek=1","et=0,1",
          "cn=0,1","ch=2","ss=16","sr=44100","pw=false","vn=3","txtvers=1", NULL);
+    execlp("mDNSPublish", "mDNSPublish", tName,
+         "_raop._tcp", tPort, "tp=UDP","sm=false","sv=false","ek=1","et=0,1",
+         "cn=0,1","ch=2","ss=16","sr=44100","pw=false","vn=3","txtvers=1", NULL);
     if(errno == -1) {
             perror("error");
     }
 
-    slog(LOG_INFO, "Bad error... couldn't find or failed to run: avahi-publish-service OR dns-sd\n");
+    slog(LOG_INFO, "Bad error... couldn't find or failed to run: avahi-publish-service OR dns-sd OR mDNSPublish\n");
     exit(1);
   }
   else

--- a/shairport.pl
+++ b/shairport.pl
@@ -113,7 +113,7 @@ sub usage {
           "Options:\n".
           "  -a, --apname=AirPort            Sets AirPort name\n".
           "  -p, --password=secret           Sets password\n",
-          "  -o, --server_port=5002          Sets Port for Avahi/dns-sd\n",
+          "  -o, --server_port=5002          Sets Port for Avahi/dns-sd/howl\n",
           "  -i, --pipe=pipepath             Sets the path to a named pipe for output\n",
           "      --ao_driver=driver          Sets the ao driver (optional)\n",
           "      --ao_devicename=devicename  Sets the ao device name (optional)\n",
@@ -281,7 +281,12 @@ if ($avahi_publish==0) {
         ".",
          $port,
         "tp=UDP","sm=false","sv=false","ek=1","et=0,1","cn=0,1","ch=2","ss=16","sr=44100",$pw_clause,"vn=3","txtvers=1"; };
-    die "could not run avahi-publish-service nor dns-sd";
+    { exec 'mDNSPublish',
+        join('', map { sprintf "%02X", $_ } @hw_addr) . "\@$apname",
+        "_raop._tcp",
+         $port,
+        "tp=UDP","sm=false","sv=false","ek=1","et=0,1","cn=0,1","ch=2","ss=16","sr=44100",$pw_clause,"vn=3","txtvers=1"; };
+    die "could not run avahi-publish-service nor dns-sd nor mDNSPublish";
 }
 
 my $airport_pem = join '', <DATA>;


### PR DESCRIPTION
Howl hasn't been actively developed for some years now; their website 404s,
and the Wayback Machine archive of 2008 says it's dead.[1] Yet it's still
functional and is much smaller than dbus and avahi, which makes it useful
for embedded systems. In fact, OpenWrt has not dropped support for the howl
tools, and it's because of howl that I can fit a functional shairport and
supporting libraries and kernel onto the 4MB of flash in a TP-LINK
TL-WR703N.[2]

[1] http://web.archive.org/web/20080917182117/http://www.porchdogsoft.com/products/howl/
[2] http://embeddedtimes.blogspot.com/2011/09/tp-link-tl-wr703n-tiny-linux-capable.html
