### PR TITLE
Ensure only one hairtunes instance runs at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-hairtunes
+hairtunes-bin
 shairport
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 CFLAGS:=-O2 -Wall $(shell pkg-config --cflags openssl ao)
 LDFLAGS:=-lm -lpthread $(shell pkg-config --libs openssl ao)
 OBJS=socketlib.o shairport.o alac.o hairtunes.o
-all: hairtunes shairport
+all: hairtunes-bin shairport
 
-hairtunes: hairtunes.c alac.o
+hairtunes-bin: hairtunes.c alac.o
 	$(CC) $(CFLAGS) -DHAIRTUNES_STANDALONE hairtunes.c alac.o -o $@ $(LDFLAGS)
 
 shairport: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
 
 clean:
-	-@rm -rf hairtunes shairport $(OBJS)
+	-@rm -rf hairtunes-bin shairport $(OBJS)
 
 
 %.o: %.c
@@ -18,7 +18,8 @@ clean:
 
 
 prefix=/usr/local
-install: hairtunes shairport
+install: hairtunes-bin shairport
+	install -D -m 0755 hairtunes-bin $(DESTDIR)$(prefix)/bin/hairtunes-bin
 	install -D -m 0755 hairtunes $(DESTDIR)$(prefix)/bin/hairtunes
 	install -D -m 0755 shairport.pl $(DESTDIR)$(prefix)/bin/shairport.pl
 	install -D -m 0755 shairport $(DESTDIR)$(prefix)/bin/shairport

--- a/hairtunes
+++ b/hairtunes
@@ -1,0 +1,6 @@
+#!/bin/bash
+timeout 10s killall -w -u "$USER" hairtunes-bin
+timeout 10s killall -SIGKILL -w -u "$USER" hairtunes-bin
+
+exec "`dirname "$0"`"/hairtunes-bin "$@"
+


### PR DESCRIPTION
This fixes #149 (Turning on 'Airplane Mode' on the source device makes hairtunes stall)
- hairtunes has been renamed to hairtunes-bin
- Add a shell script that:
  1. checks if hairtunes-bin is running already and kills it.
  2. executes hairtunes-bin
