### PR TITLE
Fixed Issue #147.

### DIFF
--- a/hairtunes.c
+++ b/hairtunes.c
@@ -451,10 +451,17 @@ static void *rtp_thread_func(void *arg) {
             plen -= 12;
 
             // check if packet contains enough content to be reasonable
-            if (plen < 16)
-                continue;
-
-            buffer_put_packet(seqno, pktp, plen);
+            if (plen >= 16) {
+                buffer_put_packet(seqno, pktp, plen);
+            } else {
+                // resync?
+                if (type == 0x56 && seqno == 0) {
+                    fprintf(stderr, "Suspected resync request packet received. Initiating resync.\n");
+                    pthread_mutex_lock(&ab_mutex);
+                    ab_resync();
+                    pthread_mutex_unlock(&ab_mutex);
+                }
+            }
         }
     }
 

--- a/hairtunes.c
+++ b/hairtunes.c
@@ -445,7 +445,16 @@ static void *rtp_thread_func(void *arg) {
                 plen -= 4;
             }
             seqno = ntohs(*(unsigned short *)(pktp+2));
-            buffer_put_packet(seqno, pktp+12, plen-12);
+
+            // adjust pointer and length
+            pktp += 12;
+            plen -= 12;
+
+            // check if packet contains enough content to be reasonable
+            if (plen < 16)
+                continue;
+
+            buffer_put_packet(seqno, pktp, plen);
         }
     }
 


### PR DESCRIPTION
When requesting resend of packets a lot, iOS sometimes sends a packet with type 0x56 (Reply to resend request), but with sequence number 0 and length == 4. This short length leads to memory corruption later on when processing the packet: alac_decode() expects at least 16 bytes for AES IV. Therefore the segfault.

This fix ignores packets with length < 16, as seen in another implementation here:
http://fossies.org/dox/mythtv-0.25.1/mythraopconnection_8cpp_source.html#l00555

Please be aware that this just fixes the segfault. The suspicious packet seems to be an information of an out of sync situation, so it may deserve further attention.

Signed-off-by: Gregor Fabritius gre@g0r.de
