### PR TITLE
Fixes for ipv4 networks and building on FreeBSD

### DIFF
--- a/FreeBSD.notes
+++ b/FreeBSD.notes
@@ -1,0 +1,4 @@
+/usr/ports/security/p5-Crypt-RSA
+/usr/ports/security/p5-Crypt-OpenSSL-RSA
+net/p5-Net-SDP
+/usr/ports/net/p5-IO-Socket-INET6

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,10 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
 
     pkg_add -r gmake libao avahi p5-libwww p5-Crypt-OpenSSL-RSA p5-Net-SDP p5-IO-Socket-INET6
     gmake
-    perl shairport.pl
+    # ipv6 does not work for me, but maybe works for you?  might be due to not
+    # having local ipv6 working dns names?
+    # force ipv4 on FreeBSD with '-4' on the command line.
+    perl shairport.pl -4
 
 ## Mac OS X:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,6 +50,12 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
     gmake
     perl shairport.pl
 
+## FreeBSD
+
+    pkg_add -r gmake libao avahi p5-libwww p5-Crypt-OpenSSL-RSA p5-Net-SDP p5-IO-Socket-INET6
+    gmake
+    perl shairport.pl
+
 ## Mac OS X:
 
   * install XCode

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
-CFLAGS:=-O2 -Wall $(shell pkg-config --cflags openssl ao)
-LDFLAGS:=-lm -lpthread $(shell pkg-config --libs openssl ao)
+
+MY_CFLAGS= $(shell pkg-config --cflags ao)
+MY_LDFLAGS= $(shell pkg-config --libs ao)
+ifeq ($(shell uname),FreeBSD)
+MY_LDFLAGS+= -lssl
+else
+MY_CFLAGS+= $(shell pkg-config --cflags openssl)
+MY_LDFLAGS+= $(shell pkg-config --libs openssl)
+endif
+
+CFLAGS:=-O2 -Wall $(MY_CFLAGS)
+LDFLAGS:=-lm -lpthread $(MY_LDFLAGS)
+
 OBJS=socketlib.o shairport.o alac.o hairtunes.o
 all: hairtunes shairport
 

--- a/shairport.pl
+++ b/shairport.pl
@@ -82,6 +82,9 @@ my $writepid;
 # show help
 my $help;
 
+
+my $ipv4;
+
 unless (-x $hairtunes_cli) {
     say "Can't find the 'hairtunes' decoder binary, you need to build this before using ShairPort.";
     say "Read the INSTALL instructions!";
@@ -97,6 +100,7 @@ GetOptions("a|apname=s" => \$apname,
           "ao_devicename=s" => \$libao_devicename,
           "ao_deviceid=s" => \$libao_deviceid,
           "v|verbose" => \$verbose,
+	  "4" => \$ipv4,
           "w|writepid=s" => \$writepid,
           "s|squeezebox" => \$squeeze,
           "c|cliport=s" => \$cliport,
@@ -295,6 +299,7 @@ my $rsa = Crypt::OpenSSL::RSA->new_private_key($airport_pem) || die "RSA private
 
 my $listen;
 {
+    if (!defined($ipv4)) {
     eval {
         local $SIG{__DIE__};
         $listen = new IO::Socket::INET6(Listen => 1,
@@ -308,6 +313,7 @@ my $listen;
               "* IO::Socket::INET6 not present!     *\n",
               "* Install this if iTunes won't play. *\n",
               "**************************************\n\n";
+    }
     }
 
     $listen ||= new IO::Socket::INET(Listen => 1,
@@ -491,6 +497,7 @@ sub performSqueezeboxSetup {
 };
 
 while (1) {
+    printf "about to select\n" if $verbose;
     my @waiting = $sel->can_read;
     foreach my $fh (@waiting) {
         if ($fh==$listen) {
@@ -507,6 +514,7 @@ while (1) {
 
             # the 2nd connection is a player connection
             if (defined($play_prog) && $sel->count() == 2) {
+		printf "play prog: $play_prog\n" if ($verbose);
                 system($play_prog);
             }
         } else {
@@ -540,6 +548,8 @@ exit(1); # Unreachable
 sub conn_handle_data {
     my $fh = shift;
     my $conn = $conns{$fh};
+
+    printf "handle data 1\n" if ($verbose);
 
     if ($conn->{req_need}) {
         if (length($conn->{data}) >= $conn->{req_need}) {
@@ -675,7 +685,7 @@ sub conn_handle_request {
 
             my $dec = $hairtunes_cli . join(' ', '', map { sprintf "%s '%s'", $_, $dec_args{$_} } keys(%dec_args));
 
-            #    print "decode command: $dec\n";
+            print "decode command: $dec\n" if ($verbose);
             my $decoder = open2(my $dec_out, my $dec_in, $dec);
 
             $conn->{decoder_pid} = $decoder;
@@ -701,10 +711,15 @@ sub conn_handle_request {
         };
         /^SET_PARAMETER$/ && do {
             my @lines = split /[\r\n]+/, $req->content;
+                printf("SET_PARAMETER req: " . $req->content . "\n") if ($verbose);
             my %content = map { /^(\S+): (.+)/; (lc $1, $2) } @lines;
             my $cfh = $conn->{decoder_fh};
             if (exists $content{volume}) {
+                printf("sending-> vol: %f\n", $content{volume}) if ($verbose);
                 printf $cfh "vol: %f\n", $content{volume};
+            } else {
+                printf("unable to perform content for req: " . $req->content . "\n") if ($verbose);
+
             }
             last;
         };
@@ -713,6 +728,7 @@ sub conn_handle_request {
         die("Unknown method: $_");
     }
 
+    printf("%s", $resp->as_string("\r\n")) if ($verbose);
     print $fh $resp->as_string("\r\n");
     $fh->flush;
 }

--- a/shairport.pl
+++ b/shairport.pl
@@ -83,7 +83,7 @@ my $writepid;
 my $help;
 
 
-my $ipv4;
+my $ipv4_only;
 
 unless (-x $hairtunes_cli) {
     say "Can't find the 'hairtunes' decoder binary, you need to build this before using ShairPort.";
@@ -100,7 +100,7 @@ GetOptions("a|apname=s" => \$apname,
           "ao_devicename=s" => \$libao_devicename,
           "ao_deviceid=s" => \$libao_deviceid,
           "v|verbose" => \$verbose,
-	  "4" => \$ipv4,
+	  "4" => \$ipv4_only,
           "w|writepid=s" => \$writepid,
           "s|squeezebox" => \$squeeze,
           "c|cliport=s" => \$cliport,
@@ -299,7 +299,7 @@ my $rsa = Crypt::OpenSSL::RSA->new_private_key($airport_pem) || die "RSA private
 
 my $listen;
 {
-    if (!defined($ipv4)) {
+    if (!defined($ipv4_only)) {
     eval {
         local $SIG{__DIE__};
         $listen = new IO::Socket::INET6(Listen => 1,
@@ -684,6 +684,10 @@ sub conn_handle_request {
             $dec_args{ao_deviceid} = $libao_deviceid if defined $libao_deviceid;
 
             my $dec = $hairtunes_cli . join(' ', '', map { sprintf "%s '%s'", $_, $dec_args{$_} } keys(%dec_args));
+
+	    if ($ipv4_only) {
+		$dec .= " ipv4_only";
+	    }
 
             print "decode command: $dec\n" if ($verbose);
             my $decoder = open2(my $dec_out, my $dec_in, $dec);


### PR DESCRIPTION
I found that the shairport.pl script does not seem to pass along its decision to use ipv4 to the hairtunes executable.  This results in the perl script setting up ipv4 transport while the hairtunes will default to ipv6.  When this happens airtunes clients (itunes/iphone) can not stream to the device because it seems to need entirely ipv4 OR ipv6.

In addition I have modified the build flags for FreeBSD hosts which ship with libssl to directly call -lssl versus using pkg-config.
