### PR TITLE
Added option to link shairport with avahi, rather than calling it externally.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,10 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
     make
     perl shairport.pl
 
+    Note: to compile shairport binary so it can be run directly with avahi linked in, 
+    uncomment the line setting LINK_AVAHI line in the Makefile, make, and then run ./shairport.
+    You will need the "libavahi-cilent-dev" package installed to build
+
 ## Redhat/Fedora:
 
     yum install openssl-devel libao libao-devel perl-Crypt-OpenSSL-RSA perl-IO-Socket-INET6 perl-libwww-perl avahi-tools

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,8 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
     perl shairport.pl
 
     Note: to compile shairport binary so it can be run directly with avahi linked in, 
-    uncomment the line setting LINK_AVAHI line in the Makefile, make, and then run ./shairport.
-    You will need the "libavahi-cilent-dev" package installed to build
+    uncomment the line setting LINKAVAHI line in the Makefile, make, and then run ./shairport.
+    You will need the "libavahi-client-dev" package installed to build
 
 ## Redhat/Fedora:
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Uncomment this if you have the avahi client libraries installed and you want to
+# link avahi directly to shairport rather than calling avahi-publish-service as
+# a subprocess. The advantage of linking it directly is it's a cleaner approach
+# than execp, and the avahi service will reliably unpublish when shairport dies.
+#
+# LINKAVAHI := 1
+
 
 MY_CFLAGS= $(shell pkg-config --cflags ao)
 MY_LDFLAGS= $(shell pkg-config --libs ao)
@@ -10,6 +17,11 @@ endif
 
 CFLAGS:=-O2 -Wall $(MY_CFLAGS)
 LDFLAGS:=-lm -lpthread $(MY_LDFLAGS)
+ifdef LINKAVAHI
+    CFLAGS := $(CFLAGS) $(shell pkg-config --cflags avahi-client) -DLINKAVAHI
+    LDFLAGS := $(LDFLAGS) $(shell pkg-config --libs avahi-client)
+endif
+
 
 OBJS=socketlib.o shairport.o alac.o hairtunes.o
 all: hairtunes shairport


### PR DESCRIPTION
Added the option to link "shairport" binary with avahi, rather than calling the external "avahi-publish-service" command. This is cleaner, and it means the service broadcast is reliably removed on crash or exit. To enable: uncomment the line setting LINKAVAHI in the Makefile. Requires the libavahi-client-dev package on Ubuntu/Debian to compile.
