### PR TITLE
IPV4 fix for OpenWRT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 LDFLAGS+=-lm -lpthread -lao $(shell pkg-config --libs openssl)
 
 
-SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c
+SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c audio_ao.c
 
-ifdef CONFIG_AO
-SRCS += audio_ao.c
-endif
+#ifdef CONFIG_AO
+#SRCS += audio_ao.c
+#endif
 
 shairport: $(SRCS)
 	$(CC) $(CFLAGS) $(SRCS) $(LDFLAGS) -o shairport

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
-ifeq ($(wildcard config.mk),)
-$(warning config.mk does not exist, configuring.)
-config.mk:
-	sh ./configure
-	$(MAKE) shairport
-endif
+#QVS modified to work with OPENWRT
 
--include config.mk
+LDFLAGS+=-lm -lpthread -lao $(shell pkg-config --libs openssl)
+
 
 SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c
 

--- a/rtsp.c
+++ b/rtsp.c
@@ -676,7 +676,8 @@ void rtsp_listen_loop(void) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_PASSIVE;
+    // Igniore protocols not enabled (helps with IPv4 support)
+    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
 
     snprintf(portstr, 6, "%d", config.port);
 


### PR DESCRIPTION
Hi perhaps ignore the changes to the makefile (had to do this to support openwrt compiled on Ubuntu) but see change to rtsp.c to fix IPV4..

Maybe this is just an error making the real issue for the challenge response..

Without it the running code errors with
"could not bind a listen socket: Bad file descriptor
Listening for connections."
