### PR TITLE
change getopt return from char to int

### DIFF
--- a/audio_ao.c
+++ b/audio_ao.c
@@ -49,7 +49,8 @@ static int init(int argc, char **argv) {
 
     optind = 0;
     // some platforms apparently require optreset = 1; - which?
-    char opt, *mid;
+    int opt;
+    char *mid;
     while ((opt = getopt(argc, argv, "d:i:n:o:")) > 0) {
         switch (opt) {
             case 'd':

--- a/shairport.c
+++ b/shairport.c
@@ -73,7 +73,7 @@ void usage(char *progname) {
 }
 
 int parse_options(int argc, char **argv) {
-    char opt;
+    int opt;
     while ((opt = getopt(argc, argv, "+hvp:a:o:b:")) > 0) {
         switch (opt) {
             default:


### PR DESCRIPTION
according to `man 3 getopt` getopt returns an int which gets -1 when no more options are available. You used to store the return value of getopt in a char, which is a unsigned 8 bit integer. As such it can actually never get -1.

So on my RasPi `gcc version 4.6.3 (Debian 4.6.3-14+rpi1)` did not leave the while loop correctly, even when no option was specified.
