### PR TITLE
Compile fixes for OpenBSD, and call freeaddrinfo() in rtp.c

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -28,7 +28,9 @@
 #include <signal.h>
 #include <unistd.h>
 #include <memory.h>
+#include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include "common.h"
 #include "player.h"

--- a/rtp.c
+++ b/rtp.c
@@ -104,6 +104,8 @@ static int bind_port(SOCKADDR *remote) {
     sock = socket(remote->SAFAMILY, SOCK_DGRAM, IPPROTO_UDP);
     ret = bind(sock, info->ai_addr, info->ai_addrlen);
 
+    freeaddrinfo(info);
+
     if (ret < 0)
         die("could not bind a UDP port!");
 

--- a/rtsp.c
+++ b/rtsp.c
@@ -27,6 +27,7 @@
 #include <memory.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <sys/select.h>
 #include <signal.h>
 #include <netdb.h>

--- a/rtsp.c
+++ b/rtsp.c
@@ -45,6 +45,12 @@
 #include "rtp.h"
 #include "mdns.h"
 
+// some BSDs (OpenBSD, NetBSD) do not support AI_ADDRCONFIG
+// it's not critical anyway, define it to 0 (a no-op)
+#ifndef AI_ADDRCONFIG
+#define AI_ADDRCONFIG 0
+#endif
+
 // only one thread is allowed to use the player at once.
 // it monitors the request variable (at least when interrupted)
 static pthread_mutex_t playing_mutex = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Added compile fixes for OpenBSD:
- add #includes like <netinet/in.h>, so IPV6_V6ONLY, IPPROTO_TCP, and others get defined
- define AI_ADDRCONFIG (which is not supported on OpenBSD/NetBSD)

Also, call freeaddrinfo() in rtp.c, to free the memory allocated by getaddrinfo()

1.0-dev is working for me on OpenBSD 5.2/i386
