### PR TITLE
Update Makefile to support OpenWRT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-CFLAGS+=-Wall $(shell pkg-config --cflags openssl) -DDISABLESTUFF
+CFLAGS+=-Wall $(shell pkg-config --cflags openssl) -DCONFIG_AO
 
-LDFLAGS+=-lm -lpthread $(shell pkg-config --libs openssl)
+LDFLAGS+=-lm -lpthread $(shell pkg-config --libs openssl) $(shell pkg-config --libs ao)
 
 
 PREFIX ?= /usr/local
 
-SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_ao.c 
+SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c audio_ao.c 
 
 
 # default target

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,12 @@
-ifeq ($(wildcard config.mk),)
-$(warning config.mk does not exist, configuring.)
-config.mk:
-	sh ./configure
-	$(MAKE) shairport
-endif
+CFLAGS+=-Wall $(shell pkg-config --cflags openssl) -DDISABLESTUFF
 
--include config.mk
+LDFLAGS+=-lm -lpthread $(shell pkg-config --libs openssl)
+
 
 PREFIX ?= /usr/local
 
-SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c
+SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_ao.c 
 
-ifdef CONFIG_AO
-SRCS += audio_ao.c
-endif
 
 # default target
 all: shairport

--- a/audio.c
+++ b/audio.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "audio.h"
-#include "config.h"
+//#include "config.h"
 
 #ifdef CONFIG_AO
 extern audio_output audio_ao;


### PR DESCRIPTION
Is it possible to update the makefile as detailed to no longer use Configure?  This makes it compatible as a package for OpenWRT where it is "made" as part of a wider process..

Thanks
