### PR TITLE
Add a PulseAudio output driver.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ ifdef CONFIG_AO
 SRCS += audio_ao.c
 endif
 
+ifdef CONFIG_PULSE
+    SRCS += audio_pulse.c
+endif
+
 ifdef CONFIG_AVAHI
 SRCS += avahi.c
 endif

--- a/audio.c
+++ b/audio.c
@@ -32,9 +32,15 @@
 #ifdef CONFIG_AO
 extern audio_output audio_ao;
 #endif
+#ifdef CONFIG_PULSE
+extern audio_output audio_pulse;
+#endif
 extern audio_output audio_dummy, audio_pipe;
 
 static audio_output *outputs[] = {
+#ifdef CONFIG_PULSE
+    &audio_pulse,
+#endif
 #ifdef CONFIG_AO
     &audio_ao,
 #endif

--- a/audio_pulse.c
+++ b/audio_pulse.c
@@ -1,0 +1,109 @@
+/*
+ * PulseAudio output driver. This file is part of Shairport.
+ * Copyright (c) Paul Lietar 2013
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#include <stdio.h>
+#include <unistd.h>
+#include <memory.h>
+#include <pulse/simple.h>
+#include <pulse/error.h>
+#include "common.h"
+#include "audio.h"
+
+pa_simple *pa_dev = NULL;
+int pa_error;
+
+static void help(void) {
+    printf("    -a server set the server name\n"
+           "    -s sink   set the output sink\n"
+          );
+}
+
+static int init(int argc, char **argv) {
+    const char *server = NULL;
+    const char *sink = NULL;
+
+    optind = 0;
+    // some platforms apparently require optreset = 1; - which?
+    int opt;
+    char *mid;
+    while ((opt = getopt(argc, argv, "a:s:")) > 0) {
+        switch (opt) {
+            case 'a':
+                server = optarg;
+                break;
+            case 's':
+                sink = optarg;
+                break;
+            default:
+                help();
+                die("Invalid audio option -%c specified", opt);
+        }
+    }
+
+    static const pa_sample_spec ss = {
+            .format = PA_SAMPLE_S16LE,
+            .rate = 44100,
+            .channels = 2
+    };
+
+
+    pa_dev = pa_simple_new(server, "shairport", PA_STREAM_PLAYBACK, sink, "shairport", &ss, NULL, NULL, &pa_error);
+
+    return pa_dev ? 0 : 1;
+}
+
+static void deinit(void) {
+    if (pa_dev)
+        pa_simple_free(pa_dev);
+    pa_dev = NULL;
+}
+
+static void start(int sample_rate) {
+    if (sample_rate != 44100)
+        die("unexpected sample rate!");
+}
+
+static void play(short buf[], int samples) {
+    if( pa_simple_write(pa_dev, (char *)buf, (size_t)samples * 4, &pa_error) < 0 )
+        fprintf(stderr, __FILE__": pa_simple_write() failed: %s\n", pa_strerror(pa_error));
+}
+
+static void stop(void) {
+    if (pa_simple_drain(pa_dev, &pa_error) < 0)
+        fprintf(stderr, __FILE__": pa_simple_drain() failed: %s\n", pa_strerror(pa_error));
+}
+
+audio_output audio_pulse = {
+    .name = "pulse",
+    .help = &help,
+    .init = &init,
+    .deinit = &deinit,
+    .start = &start,
+    .stop = &stop,
+    .play = &play,
+    .volume = NULL
+};

--- a/audio_pulse.c
+++ b/audio_pulse.c
@@ -37,14 +37,18 @@ static pa_simple *pa_dev = NULL;
 static int pa_error;
 static const char *pa_server = NULL;
 static const char *pa_sink = NULL;
+static const char *pa_appname = NULL;
 
 static void help(void) {
     printf("    -a server set the server name\n"
            "    -s sink   set the output sink\n"
+           "    -n name   set the application name, as seen by PulseAudio\n"
+           "                  defaults to the access point name\n"
           );
 }
 
 static int init(int argc, char **argv) {
+    pa_appname = config.apname;
 
     optind = 1; // optind=0 is equivalent to optind=1 plus special behaviour
     argv--;     // so we shift the arguments to satisfy getopt()
@@ -53,13 +57,16 @@ static int init(int argc, char **argv) {
     // some platforms apparently require optreset = 1; - which?
     int opt;
     char *mid;
-    while ((opt = getopt(argc, argv, "a:s:")) > 0) {
+    while ((opt = getopt(argc, argv, "a:s:n:")) > 0) {
         switch (opt) {
             case 'a':
                 pa_server = optarg;
                 break;
             case 's':
                 pa_sink = optarg;
+                break;
+            case 'n':
+                pa_appname = optarg;
                 break;
             default:
                 help();
@@ -84,10 +91,10 @@ static void start(int sample_rate) {
     };
 
     pa_dev = pa_simple_new(pa_server,
-            "shairport",
+            pa_appname,
             PA_STREAM_PLAYBACK,
             pa_sink,
-            "shairport",
+            "Shairport Stream",
             &ss, NULL, NULL,
             &pa_error);
 

--- a/audio_pulse.c
+++ b/audio_pulse.c
@@ -46,7 +46,10 @@ static void help(void) {
 
 static int init(int argc, char **argv) {
 
-    optind = 0;
+    optind = 1; // optind=0 is equivalent to optind=1 plus special behaviour
+    argv--;     // so we shift the arguments to satisfy getopt()
+    argc++;
+
     // some platforms apparently require optreset = 1; - which?
     int opt;
     char *mid;
@@ -64,6 +67,9 @@ static int init(int argc, char **argv) {
         }
     }
 
+    if (optind < argc)
+        die("Invalid audio argument: %s", argv[optind]); 
+
     return 0;
 }
 
@@ -77,7 +83,14 @@ static void start(int sample_rate) {
             .channels = 2
     };
 
-    pa_dev = pa_simple_new(pa_server, "shairport", PA_STREAM_PLAYBACK, pa_sink, "shairport", &ss, NULL, NULL, &pa_error);
+    pa_dev = pa_simple_new(pa_server,
+            "shairport",
+            PA_STREAM_PLAYBACK,
+            pa_sink,
+            "shairport",
+            &ss, NULL, NULL,
+            &pa_error);
+
     if (!pa_dev)
         die("Could not connect to pulseaudio server: %s", pa_strerror(pa_error));
 }

--- a/configure
+++ b/configure
@@ -25,6 +25,16 @@ else
     echo libao or its dev package not found
 fi
 
+if pkg-config libpulse-simple 2>/dev/null; then
+    CFLAGS="${CFLAGS} `pkg-config --cflags libpulse-simple`"
+    LDFLAGS="${LDFLAGS} `pkg-config --libs libpulse-simple`"
+    echo "#define CONFIG_PULSE" >> config.h
+    echo "CONFIG_PULSE=yes" >> config.mk
+    echo libpulse found
+else
+    echo libpulse or its dev package not found
+fi
+
 if pkg-config avahi-client 2>/dev/null; then
     CFLAGS="${CFLAGS} `pkg-config --cflags avahi-client`"
     LDFLAGS="${LDFLAGS} `pkg-config --libs avahi-client`"


### PR DESCRIPTION
For some reason, using libao was slow and didn't work well on my raspberry pi.
This patch adds a new PulseAudio output driver. It uses libpulse's synchronous API.
