### PR TITLE
Fix libao output driver.

### DIFF
--- a/audio_ao.c
+++ b/audio_ao.c
@@ -55,7 +55,7 @@ static int init(int argc, char **argv) {
         switch (opt) {
             case 'd':
                 driver = ao_driver_id(optarg);
-                if (!driver)
+                if (driver < 0)
                     die("could not find ao driver %s", optarg);
                 break;
             case 'i':


### PR DESCRIPTION
The driver id returned by libao wasn't checked correctly.
When the driver did not exist, libao returns a negative number. The
libao output driver checked for a non zero id.
This caused shairport to refuse to use the first driver, and not fail
when using a non-existant driver.
