### PR TITLE
Improve daemon mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 PREFIX ?= /usr/local
 
-SRCS := shairport.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c audio_pipe.c
+SRCS := shairport.c daemon.c rtsp.c mdns.c common.c rtp.c player.c alac.c audio.c audio_dummy.c audio_pipe.c
 
 ifdef CONFIG_AO
 SRCS += audio_ao.c

--- a/common.h
+++ b/common.h
@@ -27,6 +27,7 @@ typedef struct {
     int daemonise;
     int mdns_internal;
     char *cmd_start, *cmd_stop;
+    char *pidfile;
 } shairport_cfg;
 
 extern int debuglev;

--- a/common.h
+++ b/common.h
@@ -28,6 +28,8 @@ typedef struct {
     int mdns_internal;
     char *cmd_start, *cmd_stop;
     char *pidfile;
+    char *logfile;
+    char *errfile;
 } shairport_cfg;
 
 extern int debuglev;

--- a/daemon.c
+++ b/daemon.c
@@ -77,3 +77,12 @@ void daemon_ready() {
     close(daemon_pipe[1]);
 }    
 
+void daemon_exit() {
+    if (lock_fd) {
+        lockf(lock_fd, F_ULOCK, 0);
+        close(lock_fd);
+        unlink(config.pidfile);
+        lock_fd = -1;
+    }
+}
+

--- a/daemon.c
+++ b/daemon.c
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Shairport.
+ * Copyright (c) Paul Lietar 2013
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include "common.h"
+
+static int lock_fd = -1;
+static int daemon_pipe[2] = {-1, -1};
+
+void daemon_init() {
+    int ret;
+    ret = pipe(daemon_pipe);
+    if (ret < 0)
+        die("couldn't create a pipe?!");
+
+    pid_t pid = fork();
+    if (pid < 0)
+        die("failed to fork!");
+
+    if (pid) {
+        char buf[8];
+        ret = read(daemon_pipe[0], buf, sizeof(buf));
+        if (ret < 0) {
+            printf("Spawning the daemon failed.\n");
+            exit(1);
+        }
+
+        printf("%d\n", pid);
+        exit(0);
+    }
+    else {
+        if (config.pidfile) {
+            lock_fd = open(config.pidfile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+            if (lock_fd < 0) {
+                die("Could not open pidfile");
+            }
+
+            ret = lockf(lock_fd,F_TLOCK,0);
+            if (ret < 0) {
+                die("Could not lock pidfile. Is an other instance running ?");
+            }
+
+            dprintf(lock_fd, "%d\n", getpid());
+        }
+    }
+}
+
+void daemon_ready() {
+    write(daemon_pipe[1], "ok", 2);
+    close(daemon_pipe[1]);
+}    
+

--- a/daemon.h
+++ b/daemon.h
@@ -1,0 +1,7 @@
+#ifndef _DAEMON_H
+#define _DAEMON_H
+
+void daemon_init();
+void daemon_ready();
+
+#endif // _DAEMON_H

--- a/daemon.h
+++ b/daemon.h
@@ -3,5 +3,6 @@
 
 void daemon_init();
 void daemon_ready();
+void daemon_exit();
 
 #endif // _DAEMON_H

--- a/shairport.c
+++ b/shairport.c
@@ -216,8 +216,13 @@ void log_setup() {
             die("Could not open logfile");
 
         dup2(log_fd, STDOUT_FILENO);
+        setvbuf (stdout, NULL, _IOLBF, BUFSIZ);
+
         if (!config.errfile)
+        {
             dup2(log_fd, STDERR_FILENO);
+            setvbuf (stderr, NULL, _IOLBF, BUFSIZ);
+        }
     }
 
     if (config.errfile) {
@@ -228,6 +233,7 @@ void log_setup() {
             die("Could not open logfile");
 
         dup2(err_fd, STDERR_FILENO);
+        setvbuf (stderr, NULL, _IOLBF, BUFSIZ);
     }
 }
 


### PR DESCRIPTION
The daemon's process id can be written to a file, and output can be redirected to a logfile.
This makes it easier to write complete init-script.
