### PR TITLE
Reset playing_thread on connection close. Fixes #217

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -708,6 +708,7 @@ respond:
         rtp_shutdown();
         player_stop();
         please_shutdown = 0;
+        playing_thread = 0;
         pthread_mutex_unlock(&playing_mutex);
     }
     if (auth_nonce)


### PR DESCRIPTION
pthread seems to reuse thread identifiers (at least on arm).
Reset it to zero after closing a playing connection, or else future
thread might believe they are playing.
