### PR TITLE
Make a few fixes debian init script. Closes #242

### DIFF
--- a/scripts/debian/default/shairport
+++ b/scripts/debian/default/shairport
@@ -6,11 +6,15 @@
 # user should have permission to output sound
 # Check the audio output documentation for details.
 #USER=shairport
-#GROUP=nobody
+#GROUP=nogroup
 
 # Process' nice on start
 #NICE=0
 
+# File where log messages should be redirected.
+# If a non-default log or error file is used, and logrotate is configured with
+# the provided configuration file, then the paths of the log files should be
+# updated in /etc/logrotate.d/shairport to reflect the value of $LOGFILE and $ERRFILE
 #LOGFILE=/var/log/shairport.log
 
 # If empty, errors are redirected to LOGFILE

--- a/scripts/debian/init.d/shairport
+++ b/scripts/debian/init.d/shairport
@@ -1,15 +1,15 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:          skeleton
+# Provides:          shairport
 # Required-Start:    $remote_fs $networking
 # Required-Stop:     $remote_fs $networking
-# Should-Start:      pulseaudio alsa-utils hostname
-# Should-Stop:       pulseaudio alsa-utils hostname
+# Should-Start:      pulseaudio alsa-utils hostname avahi
+# Should-Stop:       pulseaudio alsa-utils hostname avahi
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-# Do not configure this file. Edit /etc/default/shairport instead!
+# Do not modify this file. Edit /etc/default/shairport instead !
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Shairport Airtunes emulator"


### PR DESCRIPTION
Add avahi as a start dependency, fix the provide line.
Also add a note about updating the logrotate file if non-standard
log and error files are used.
