### PR TITLE
Gentoo init script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,9 @@ endif
 # default target
 all: shairport
 
-install: install-exe install-init
-install-exe: shairport
+install: shairport
 	install -m 755 -d $(PREFIX)/bin
 	install -m 755 shairport $(PREFIX)/bin/shairport
-install-init: install-exe
-	if [[ "$(uname)" = "Linux" ]]; then\
-		if [[ "$(shell cat /proc/version)" = *Gentoo* ]]; then\
-			cp scripts/gentoo/openrc/init.d.sh /etc/init.d/shairport\
-			cp scripts/gentoo/openrc/conf.d.cfg /etc/conf.d/shairport\
-		fi;\
-	fi
 
 shairport: $(SRCS) config.h config.mk
 	$(CC) $(CFLAGS) $(SRCS) $(LDFLAGS) -o shairport

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,17 @@ endif
 # default target
 all: shairport
 
-install: shairport
+install: install-exe install-init
+install-exe: shairport
 	install -m 755 -d $(PREFIX)/bin
 	install -m 755 shairport $(PREFIX)/bin/shairport
+install-init: install-exe
+	if [[ "$(uname)" = "Linux" ]]; then\
+		if [[ "$(shell cat /proc/version)" = *Gentoo* ]]; then\
+			cp scripts/gentoo/openrc/init.d.sh /etc/init.d/shairport\
+			cp scripts/gentoo/openrc/conf.d.cfg /etc/conf.d/shairport\
+		fi;\
+	fi
 
 shairport: $(SRCS) config.h config.mk
 	$(CC) $(CFLAGS) $(SRCS) $(LDFLAGS) -o shairport

--- a/scripts/gentoo/openrc/conf.d.cfg
+++ b/scripts/gentoo/openrc/conf.d.cfg
@@ -10,11 +10,13 @@
 #BUF_FILL=100
 
 # The log file (for stdout, --log $LOGFILE)
-#LOGFILE=/var/log/shairport.log
+LOGFILE=/var/log/shairport.log
 
 # The error file (for stderr, --error $ERRFILE)
 #ERRFILE=/var/log/shairport.err
 
-# The backend to use (--output=$BACKEND)
+# The backend to use (--output=$BACKEND -- $BACKEND_OPTS)
+# Shairport's help (shairport -h) shows all of the available
+# backends and their options
 #BACKEND=alsa
 #BACKEND_OPTS="-d default -t software ...some other opts..."

--- a/scripts/gentoo/openrc/conf.d.cfg
+++ b/scripts/gentoo/openrc/conf.d.cfg
@@ -1,0 +1,20 @@
+# /etc/conf.d/shairport: config file for /etc/init.d/shairport
+
+# The pidfile for the shairport daemon (--pidfile=$PIDFILE)
+#PIDFILE=/var/run/shairport.pid
+
+# The name shairport advertizes (-a $NAME)
+#NAME=myairplay
+
+# How full the buffer must be before audio output starts (-b $BUF_FILL)
+#BUF_FILL=100
+
+# The log file (for stdout, --log $LOGFILE)
+#LOGFILE=/var/log/shairport.log
+
+# The error file (for stderr, --error $ERRFILE)
+#ERRFILE=/var/log/shairport.err
+
+# The backend to use (--output=$BACKEND)
+#BACKEND=alsa
+#BACKEND_OPTS="-d default -t software ...some other opts..."

--- a/scripts/gentoo/openrc/init.d.sh
+++ b/scripts/gentoo/openrc/init.d.sh
@@ -1,0 +1,47 @@
+#!/sbin/runscript
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EXEC=/usr/local/bin/shairport
+
+. /etc/conf.d/shairport
+
+depend() {
+	need net
+	after bootmisc
+}
+
+start() {
+	OPTIONS="--daemon"
+
+	if [[ -z "$PIDFILE" ]]; then PIDFILE=/var/run/shairport.pid; fi
+	OPTIONS="$OPTIONS --pidfile=$PIDFILE"
+
+	if [[ ! -z "$NAME" ]]; then OPTIONS="$OPTIONS --name=$NAME"; fi
+	
+	if [[ ! -z "$BUF_FILL" ]]; then OPTIONS="$OPTIONS -b $BUF_FILL"; fi
+
+	if [[ -z $NAME ]]
+	then
+		ebegin "Starting shairport"
+	else
+		ebegin "Starting shairport as $NAME"
+	fi
+
+	if [[ -z "$LOGFILE" ]]; then LOGFILE=/var/log/shairport.log; fi
+	OPTIONS="$OPTIONS --log $LOGFILE"
+
+	if [[ ! -z "$ERRFILE" ]]; then OPTIONS="$OPTIONS -error $ERRFILE"; fi
+
+	if [[ ! -z "$BACKEND" ]]; then OPTIONS="$OPTIONS -output=$BACKEND $BACKEND_OPTS"; fi
+	
+	start-stop-daemon --start --exec $EXEC -- $OPTIONS
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping shairport"
+	start-stop-daemon --stop --exec $EXEC
+	eend $?
+}

--- a/scripts/gentoo/openrc/init.d.sh
+++ b/scripts/gentoo/openrc/init.d.sh
@@ -1,7 +1,4 @@
 #!/sbin/runscript
-# Copyright 1999-2013 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
 EXEC=/usr/local/bin/shairport
 
@@ -29,13 +26,13 @@ start() {
 		ebegin "Starting shairport as $NAME"
 	fi
 
-	if [[ -z "$LOGFILE" ]]; then LOGFILE=/var/log/shairport.log; fi
-	OPTIONS="$OPTIONS --log $LOGFILE"
+	if [[ ! -z "$LOGFILE" ]]; then OPTIONS="$OPTIONS --log $LOGFILE"; fi
 
-	if [[ ! -z "$ERRFILE" ]]; then OPTIONS="$OPTIONS -error $ERRFILE"; fi
+	if [[ ! -z "$ERRFILE" ]]; then OPTIONS="$OPTIONS --error $ERRFILE"; fi
 
-	if [[ ! -z "$BACKEND" ]]; then OPTIONS="$OPTIONS -output=$BACKEND $BACKEND_OPTS"; fi
-	
+	if [[ ! -z "$BACKEND" ]]; then OPTIONS="$OPTIONS --output=$BACKEND $BACKEND_OPTS"; fi
+	if [[ ! -z "$BACKEND_OPTS" ]]; then OPTIONS="$OPTIONS -- $BACKEND_OPTS"; fi
+
 	start-stop-daemon --start --exec $EXEC -- $OPTIONS
 	eend $?
 }


### PR DESCRIPTION
This is a relatively trivial change that adds a init.d script and a conf.d file for gentoo. In the Makefile, I renamed `install` to `install-exe`, added a new `install` that just depends on `install-exe` and `install-init`, and added `install-init` that detects Gentoo and installs the scripts to their respective locations.

The init script checks for various variables and adds any corresponding options.
