### PR TITLE
Improvements for Arch Linux and systemd

### DIFF
--- a/scripts/PKGBUILD
+++ b/scripts/PKGBUILD
@@ -8,6 +8,8 @@ arch=('i686' 'x86_64' 'armv6h')
 license=('public-domain')
 groups=('daemons')
 depends=('glibc' 'pkgconfig' 'libao' 'openssl')
+provides=('shairport')
+conflicts=('shairport')
 source=(git://github.com/abrasive/shairport.git#branch=1.0-dev)
 md5sums=('SKIP')
 

--- a/scripts/PKGBUILD
+++ b/scripts/PKGBUILD
@@ -1,7 +1,7 @@
 # for Arch Linux
 pkgname=shairport-git
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An AirPlay-compatible audio receiver"
 url='http://github.com/abrasive/shairport'
 arch=('i686' 'x86_64' 'armv6h')
@@ -21,4 +21,6 @@ build() {
 package() {
     cd "$srcdir"/shairport
     make PREFIX="$pkgdir/usr" install
+    install -m 755 -d "$pkgdir"/usr/lib/systemd/system
+    install -m 644 scripts/shairport.service "$pkgdir"/usr/lib/systemd/system/shairport.service
 }

--- a/scripts/shairport.service
+++ b/scripts/shairport.service
@@ -5,7 +5,8 @@ Requires=avahi-daemon.service
 After=avahi-daemon.service
 
 [Service]
-ExecStart=/usr/bin/shairport
+EnvironmentFile=/etc/conf.d/shairport
+ExecStart=/usr/bin/shairport $SHAIRPORT_ARGS
 Restart=always
 
 [Install]


### PR DESCRIPTION
1. The systemd service file is now installed when using the `PKGBUILD`
2. The service can now be configured using `SHAIRPORT_ARGS` in `/etc/conf.d/shairport`
3. Modified `PKGBUILD` so that `pacman` will replace existing shairport packages.
