### PR TITLE
Init script: Fix DAEMON var (Bins go to /usr/local/bin during install)

### DIFF
--- a/scripts/debian/init.d/shairport
+++ b/scripts/debian/init.d/shairport
@@ -11,10 +11,10 @@
 
 # Do not modify this file. Edit /etc/default/shairport instead !
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
 DESC="Shairport Airtunes emulator"
 NAME=shairport
-DAEMON=/usr/bin/shairport
+DAEMON=/usr/local/bin/shairport
 
 # Configuration defaults
 USER=shairport


### PR DESCRIPTION
I recently installed shairport on my raspberry pi and wondered why it's telling me "drecksding not installed" (drecksding is the hostname of the pi). Ignoring the fact, that this message is a bit confusing, I managed to get it running with this patch. 

`make install` copies the binary to `/usr/local/bin/shairport` while `DAEMON` is set to `/usr/bin/shairport`
