### PR TITLE
Update init script to look for shairport in Makefile prefix

### DIFF
--- a/common.c
+++ b/common.c
@@ -57,6 +57,8 @@ void die(char *format, ...) {
 }
 
 void warn(char *format, ...) {
+    if (shairport_cfg.quiet)
+        return;
     fprintf(stderr, "WARNING: ");
     va_list args;
     va_start(args, format);

--- a/common.c
+++ b/common.c
@@ -57,7 +57,7 @@ void die(char *format, ...) {
 }
 
 void warn(char *format, ...) {
-    if (shairport_cfg.quiet)
+    if (config.quiet)
         return;
     fprintf(stderr, "WARNING: ");
     va_list args;

--- a/common.h
+++ b/common.h
@@ -32,6 +32,7 @@ typedef struct {
     char *pidfile;
     char *logfile;
     char *errfile;
+    char *quiet;
 } shairport_cfg;
 
 extern int debuglev;

--- a/common.h
+++ b/common.h
@@ -32,7 +32,6 @@ typedef struct {
     char *pidfile;
     char *logfile;
     char *errfile;
-    char *quiet;
 } shairport_cfg;
 
 extern int debuglev;

--- a/scripts/debian/init.d/shairport
+++ b/scripts/debian/init.d/shairport
@@ -14,7 +14,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Shairport Airtunes emulator"
 NAME=shairport
-DAEMON=/usr/bin/shairport
+DAEMON=/usr/local/bin/shairport
 
 # Configuration defaults
 USER=shairport

--- a/shairport.c
+++ b/shairport.c
@@ -144,6 +144,9 @@ int parse_options(int argc, char **argv) {
             case 'd':
                 config.daemonise = 1;
                 break;
+            case 'q':
+                config.quiet = 1;
+                break;
             case 'v':
                 debuglev++;
                 break;
@@ -176,9 +179,6 @@ int parse_options(int argc, char **argv) {
                 break;
             case 'm':
                 config.mdns_name = optarg;
-                break;
-            case 'q':
-                config.quiet = 1;
                 break;
         }
     }

--- a/shairport.c
+++ b/shairport.c
@@ -176,7 +176,7 @@ int parse_options(int argc, char **argv) {
                 config.mdns_name = optarg;
                 break;
             case 'q':
-                config.quiet = optarg;
+                config.quiet = 1;
                 break;
         }
     }

--- a/shairport.c
+++ b/shairport.c
@@ -85,6 +85,7 @@ void usage(char *progname) {
     printf("\n");
     printf("Options:\n");
     printf("    -h, --help          show this help\n");
+    printf("    -q, --quiet         do not print any messages (useful for Raspberry Pi)\n");
     printf("    -p, --port=PORT     set RTSP listening port\n");
     printf("    -a, --name=NAME     set advertised name\n");
     printf("    -b FILL             set how full the buffer must be before audio output\n");
@@ -118,6 +119,7 @@ int parse_options(int argc, char **argv) {
     static struct option long_options[] = {
         {"help",    no_argument,        NULL, 'h'},
         {"daemon",  no_argument,        NULL, 'd'},
+        {"quiet",  no_argument,        NULL, 'q'},
         {"pidfile", required_argument,  NULL, 'P'},
         {"log",     required_argument,  NULL, 'l'},
         {"error",   required_argument,  NULL, 'e'},

--- a/shairport.c
+++ b/shairport.c
@@ -132,7 +132,7 @@ int parse_options(int argc, char **argv) {
 
     int opt;
     while ((opt = getopt_long(argc, argv,
-                              "+hdvP:l:e:p:a:o:b:B:E:m:",
+                              "+hdvP:l:e:p:a:o:b:B:E:m:q:",
                               long_options, NULL)) > 0) {
         switch (opt) {
             default:
@@ -174,6 +174,9 @@ int parse_options(int argc, char **argv) {
                 break;
             case 'm':
                 config.mdns_name = optarg;
+                break;
+            case 'q':
+                config.quiet = optarg;
                 break;
         }
     }


### PR DESCRIPTION
The current system v init script looks for the shairport binary in a different place than the default Makefile prefix. This is unintuitive.
