### PR TITLE
Exit successfully with --help

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -136,9 +136,11 @@ int parse_options(int argc, char **argv) {
                               long_options, NULL)) > 0) {
         switch (opt) {
             default:
-            case 'h':
                 usage(argv[0]);
                 exit(1);
+            case 'h':
+                usage(argv[0]);
+                exit(0);
             case 'd':
                 config.daemonise = 1;
                 break;


### PR DESCRIPTION
Passing `--help` is a legitimate use, so it should not `exit(1)`. Besides, this is
useful to test whether the command is available.
