### PR TITLE
fix retransmit: make sure to report our control port at setup

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -57,8 +57,10 @@ static void *rtp_receiver(void *arg) {
 
         ssize_t plen = nread;
         uint8_t type = packet[1] & ~0x80;
-        if (type == 0x60 || type == 0x56) {   // audio data / resend
+        if (type == 0x60 || type == 0x56 || type == 0x54) {   // audio data / resend /sync
             pktp = packet;
+            if (type == 0x54)
+                continue;
             if (type==0x56) {
                 pktp += 4;
                 plen -= 4;
@@ -176,7 +178,7 @@ void rtp_request_resend(seq_t first, seq_t last) {
     if (!running)
         die("rtp_request_resend called without active stream!");
 
-    debug(1, "requesting resend on %d packets (%04X:%04X)",
+    debug(1, "requesting resend on %d packets (%04X:%04X)\n",
          seq_diff(first,last) + 1, first, last);
 
     char req[8];    // *not* a standard RTCP NACK

--- a/rtsp.c
+++ b/rtsp.c
@@ -413,8 +413,8 @@ static void handle_setup(rtsp_conn_info *conn,
     player_play(&conn->stream);
 
     char *resphdr = malloc(strlen(hdr) + 20);
-    strcpy(resphdr, hdr);
-    sprintf(resphdr + strlen(resphdr), ";server_port=%d", sport);
+    sprintf(resphdr, "%s;server_port=%d;control_port=%d;timing_port=%d",
+            "RTP/AVP/UDP;unicast;interleaved=0-1;mode=record", sport, sport, tport);
     msg_add_header(resp, "Transport", resphdr);
 
     msg_add_header(resp, "Session", "1");


### PR DESCRIPTION
For some reason, the code expects retransmit data to be also sent to the audio port.
This tells the connecting play to do so.
verified to work with Airfoil 3.5.3, Eric Milles' Remote Speakers Output Plug 4.7 and iTunes 10.5.3.3

Frederik
