### PR TITLE
RFC: time synchronised playback

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -17,6 +17,9 @@ typedef struct {
 
     // may be NULL, in which case soft volume is applied
     void (*volume)(double vol);
+
+    //time in us it takes before a new sample is output
+    long long (*get_delay)(void);
 } audio_output;
 
 audio_output *audio_get_output(char *name);

--- a/audio.h
+++ b/audio.h
@@ -24,5 +24,7 @@ typedef struct {
 
 audio_output *audio_get_output(char *name);
 void audio_ls_outputs(void);
+long long audio_get_delay(void);
+void audio_estimate_delay(audio_output *output);
 
 #endif //_AUDIO_H

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -160,7 +160,7 @@ static void start(int sample_rate) {
     device_sample_rate = sample_rate;
 
     int ret, dir = 0;
-    snd_pcm_uframes_t frames = 64;
+    snd_pcm_uframes_t period_size,  buffer_size;
     ret = snd_pcm_open(&alsa_handle, alsa_out_dev, SND_PCM_STREAM_PLAYBACK, 0);
     if (ret < 0)
         die("Alsa initialization failed: unable to open pcm device: %s\n", snd_strerror(ret));
@@ -171,10 +171,52 @@ static void start(int sample_rate) {
     snd_pcm_hw_params_set_format(alsa_handle, alsa_params, SND_PCM_FORMAT_S16);
     snd_pcm_hw_params_set_channels(alsa_handle, alsa_params, 2);
     snd_pcm_hw_params_set_rate_near(alsa_handle, alsa_params, (unsigned int *)&sample_rate, &dir);
-    snd_pcm_hw_params_set_period_size_near(alsa_handle, alsa_params, &frames, &dir);
-    ret = snd_pcm_hw_params(alsa_handle, alsa_params);
-    if (ret < 0)
-        die("unable to set hw parameters: %s\n", snd_strerror(ret));
+
+    // setting period and buffer is a simplified version of what XBMC does
+    snd_pcm_hw_params_get_period_size_max(alsa_params, &period_size, NULL);
+    snd_pcm_hw_params_get_buffer_size_max(alsa_params, &buffer_size);
+    debug(1, "Hardware supports period_size_max: %d, buffer_size_max: %d\n", period_size, buffer_size);
+
+    // we want about 333 ms of buffer, and 50ms period
+    // buffer might still need some tweaking to get reliable operation on RPi + USB DAC...
+    // make sure we do not exceed what HW supports
+    period_size = (period_size < sample_rate / 20 ? period_size : sample_rate / 20);
+    buffer_size = (buffer_size < sample_rate / 3 ? buffer_size : sample_rate / 3);
+
+    // make sure buffer size is at least 4 times period size
+    period_size = (period_size < buffer_size / 4 ? period_size : buffer_size / 4);
+    debug(1, "Trying to set period_size: %d, buffer_size: %d\n", period_size, buffer_size);
+
+    // we keep the originals and try setting period and buffer using copies
+    snd_pcm_uframes_t period_temp, buffer_temp;
+    period_temp = period_size;
+    buffer_temp = buffer_size;
+    snd_pcm_hw_params_t *alsa_params_copy;
+    snd_pcm_hw_params_alloca(&alsa_params_copy);
+    snd_pcm_hw_params_copy(alsa_params_copy, alsa_params);
+
+    // some HW seems to be picky about the order period and buffer are set, so try both ways
+    // first try with buffer_size, period_size
+    if (snd_pcm_hw_params_set_buffer_size_near(alsa_handle, alsa_params_copy, &buffer_temp) != 0
+    		|| snd_pcm_hw_params_set_period_size_near(alsa_handle, alsa_params_copy, &period_temp, NULL) != 0
+    		|| snd_pcm_hw_params(alsa_handle, alsa_params_copy) != 0) {
+        period_temp = period_size;
+        buffer_temp = buffer_size;
+        snd_pcm_hw_params_copy(alsa_params_copy, alsa_params);
+        // retry with period_size, buffer_size
+        if (snd_pcm_hw_params_set_period_size_near(alsa_handle, alsa_params_copy, &period_temp, NULL) != 0
+        		|| snd_pcm_hw_params_set_buffer_size_near(alsa_handle, alsa_params_copy, &buffer_temp) != 0
+        		|| snd_pcm_hw_params(alsa_handle, alsa_params_copy) != 0) {
+        	// set what alsa would have
+        	warn("Setting period and buffer failed, going with the defaults\n");
+            ret = snd_pcm_hw_params(alsa_handle, alsa_params);
+            if (ret < 0)
+                die("unable to set hw parameters: %s\n", snd_strerror(ret));
+            // using alsa defaults, so see what they are
+            snd_pcm_get_params(alsa_handle, &buffer_size, &period_size);
+            debug(1, "Defaults are period_size: %d, buffer_size: %d\n", period_size, buffer_size);
+        }
+    }
 }
 
 static void play(short buf[], int samples) {

--- a/audio_ao.c
+++ b/audio_ao.c
@@ -125,5 +125,6 @@ audio_output audio_ao = {
     .start = &start,
     .stop = &stop,
     .play = &play,
-    .volume = NULL
+    .volume = NULL,
+    .get_delay = NULL
 };

--- a/audio_dummy.c
+++ b/audio_dummy.c
@@ -59,9 +59,9 @@ static void play(short buf[], int samples) {
 
     samples_played += samples;
 
-    long long finishtime = starttime + samples_played * 1e6 / Fs;
-
-    usleep(finishtime - nowtime);
+    long long sleeptime = starttime + samples_played * 1e6 / Fs - nowtime;
+    if (sleeptime > 0)
+        usleep(sleeptime );
 }
 
 static void stop(void) {

--- a/audio_pipe.c
+++ b/audio_pipe.c
@@ -136,5 +136,6 @@ audio_output audio_pipe = {
     .start = &start,
     .stop = &stop,
     .play = &play,
-    .volume = NULL
+    .volume = NULL,
+    .get_delay = NULL
 };

--- a/audio_pulse.c
+++ b/audio_pulse.c
@@ -116,6 +116,18 @@ static void stop(void) {
         fprintf(stderr, __FILE__": pa_simple_drain() failed: %s\n", pa_strerror(pa_error));
 }
 
+static long long get_delay() {
+  pa_usec_t latency;
+  latency = pa_simple_get_latency(pa_dev, &pa_error);
+  if (pa_error < 0 )
+  {
+    latency = (pa_usec_t) 0;
+    fprintf(stderr, __FILE__": get_delay() failed: %s\n", pa_strerror(pa_error));
+  }
+
+  return (long long)latency;
+}
+
 audio_output audio_pulse = {
     .name = "pulse",
     .help = &help,
@@ -124,5 +136,7 @@ audio_output audio_pulse = {
     .start = &start,
     .stop = &stop,
     .play = &play,
-    .volume = NULL
+    .volume = NULL,
+    .get_delay = &get_delay
 };
+

--- a/common.h
+++ b/common.h
@@ -26,7 +26,6 @@ typedef struct {
     audio_output *output;
     char *mdns_name;
     mdns_backend *mdns;
-    int buffer_start_fill;
     int delay;
     int daemonise;
     char *cmd_start, *cmd_stop;

--- a/common.h
+++ b/common.h
@@ -63,4 +63,14 @@ extern shairport_cfg config;
 void shairport_shutdown(int retval);
 void shairport_startup_complete(void);
 
+typedef struct {
+    double hist[2];
+    double a[2];
+    double b[3];
+} biquad_t;
+
+void biquad_init(biquad_t *bq, double a[], double b[]);
+void biquad_lpf(biquad_t *bq, double freq, double Q);
+double biquad_filt(biquad_t *bq, double in);
+
 #endif // _COMMON_H

--- a/common.h
+++ b/common.h
@@ -27,6 +27,7 @@ typedef struct {
     char *mdns_name;
     mdns_backend *mdns;
     int buffer_start_fill;
+    int delay;
     int daemonise;
     char *cmd_start, *cmd_stop;
     int cmd_blocking;

--- a/configure
+++ b/configure
@@ -106,7 +106,14 @@ check_command ${CC}
 
 check_time_function
 
-do_pkg_config OpenSSL       openssl
+# On FreeBSD, OpenSSL is always there, but no .pc file is installed,
+# so pkg-config does not report it
+if [ `uname` = 'FreeBSD' ]; then
+   echo "FreeBSD machine, assuming OpenSSL is there"
+   LDFLAGS="${LDFLAGS} -lssl -lcrypto"
+else
+   do_pkg_config OpenSSL       openssl
+fi
 do_pkg_config libao         ao              CONFIG_AO
 do_pkg_config PulseAudio    libpulse-simple CONFIG_PULSE
 do_pkg_config ALSA          alsa            CONFIG_ALSA

--- a/configure
+++ b/configure
@@ -59,6 +59,38 @@ do_pkg_config()
     fi
 }
 
+#figure out which time function to use
+check_time_function()
+{
+    cat >function_test.c <<FUNC_EOF
+#include <time.h>
+
+int main(int argc, char **argv){
+    struct timespec *tsp;
+    clock_gettime(CLOCK_MONOTONIC, tsp);
+}
+FUNC_EOF
+
+    if ${CC} ${CFLAGS} ${LDFLAGS} -c function_test.c > /dev/null 2>&1 /dev/null; then
+        echo "Found clock_gettime()"
+        echo -n "Checking if rt lib switch should be added: "
+        if ${CC} ${CFLAGS} ${LDFLAGS} function_test.c -lrt > /dev/null 2>&1 /dev/null; then
+            echo "-lrt works, adding"
+            LDFLAGS="${LDFLAGS} -lrt"
+        else
+            echo "-lrt not found, won't add"
+        fi
+    else
+        echo "Checking if we can use mach time"
+        check_header mach/mach.h
+        check_header mach/clock.h
+        export_config MACH_TIME
+    fi
+    rm -f function_test.*
+}
+
+check_time_function
+
 do_pkg_config OpenSSL       openssl
 do_pkg_config libao         ao              CONFIG_AO
 do_pkg_config PulseAudio    libpulse-simple CONFIG_PULSE

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "${CC}" ] && CC=gcc
+[ -z "${CC}" ] && CC=cc
 
 echo Configuring Shairport
 

--- a/configure
+++ b/configure
@@ -89,6 +89,21 @@ FUNC_EOF
     rm -f function_test.*
 }
 
+# Check if command is installed
+check_command()
+{
+if command -v $1 > /dev/null 2>&1; then
+   echo $1 'is installed'
+else
+   echo $1 'is missing, cannot continue'
+   exit 1
+fi
+}
+
+# First check if the tools configure needs are installed
+check_command pkg-config
+check_command ${CC}
+
 check_time_function
 
 do_pkg_config OpenSSL       openssl

--- a/player.c
+++ b/player.c
@@ -218,12 +218,6 @@ static long us_to_frames(long long us) {
     return us * sampling_rate / 1000000;
 }
 
-static inline long long get_sync_time(long long ntp_tsp) {
-    long long sync_time_est;
-    sync_time_est = (ntp_tsp + config.delay) - (tstp_us() + get_ntp_offset() + config.output->get_delay());
-    return sync_time_est;
-}
-
 void player_put_packet(seq_t seqno, sync_cfg sync_tag, uint8_t *data, int len) {
     abuf_t *abuf = 0;
     int16_t buf_fill;

--- a/player.c
+++ b/player.c
@@ -374,7 +374,7 @@ static int stuff_buffer(double playback_rate, short *inptr, short *outptr) {
 
     if (rand() < p_stuff * RAND_MAX) {
         stuff = playback_rate > 1.0 ? -1 : 1;
-        stuffsamp = rand() % (frame_size - 1);
+        stuffsamp = 1 + (rand() % (frame_size - 2));
     }
 
     pthread_mutex_lock(&vol_mutex);

--- a/player.c
+++ b/player.c
@@ -670,6 +670,12 @@ int player_play(stream_cfg *stream) {
     please_stop = 0;
     command_start();
     config.output->start(sampling_rate);
+    // generic outputs cannot report the delay, so we estimate the buffer depth
+    // at startup and hope for the best
+    if (!config.output->get_delay) {
+        config.output->get_delay = audio_get_delay;
+        audio_estimate_delay(config.output);
+    }
     pthread_create(&player_thread, NULL, player_thread_func, NULL);
 
     return 0;

--- a/player.h
+++ b/player.h
@@ -1,8 +1,20 @@
 #ifndef _PLAYER_H
 #define _PLAYER_H
 
+#include <limits.h>
 #include "audio.h"
 #include "metadata.h"
+
+#define NOSYNC 0
+#define NTPSYNC 1
+#define RTPSYNC 2
+#define E_NTPSYNC 3
+
+typedef struct {
+    long long ntp_tsp;
+    unsigned long rtp_tsp;
+    int sync_mode;
+} sync_cfg;
 
 typedef struct {
     uint8_t aesiv[16], aeskey[16];
@@ -24,9 +36,9 @@ void player_volume(double f);
 void player_metadata();
 void player_cover_image(char *buf, int len, char *ext);
 void player_cover_clear();
-void player_flush(void);
+unsigned long player_flush(int seqno, unsigned long rtp_tsp);
 void player_resync(void);
 
-void player_put_packet(seq_t seqno, uint8_t *data, int len);
+void player_put_packet(seq_t seqno, sync_cfg sync_tag, uint8_t *data, int len);
 
 #endif //_PLAYER_H

--- a/rtp.c
+++ b/rtp.c
@@ -32,47 +32,189 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <errno.h>
+#include "config.h"
 #include "common.h"
 #include "player.h"
+#ifdef MACH_TIME
+#include <mach/mach.h>
+#include <mach/clock.h>
+#endif
+
+#define NTPCACHESIZE 7
 
 // only one RTP session can be active at a time.
 static int running = 0;
 static int please_shutdown;
 
 static SOCKADDR rtp_client;
-static int sock;
+static SOCKADDR rtp_timing;
+static socklen_t addrlen;
+static int server_sock;
+static int timing_sock;
 static pthread_t rtp_thread;
+static pthread_t ntp_receive_thread;
+static pthread_t ntp_send_thread;
+long long ntp_cache[NTPCACHESIZE + 1];
+static int strict_rtp;
+
+void rtp_record(int rtp_mode){
+    debug(2, "Setting strict_rtp to %d\n", rtp_mode);
+    strict_rtp = rtp_mode;
+}
+
+static void get_current_time(struct timespec *tsp) {
+#ifdef MACH_TIME
+    kern_return_t retval = KERN_SUCCESS;
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+    retval = clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+
+    tsp->tv_sec = mts.tv_sec;
+    tsp->tv_nsec = mts.tv_nsec;
+#else
+    clock_gettime(CLOCK_MONOTONIC, tsp);
+#endif
+}
+
+static void reset_ntp_cache() {
+    int i;
+    for (i = 0; i < NTPCACHESIZE; i++) {
+        ntp_cache[i] = LLONG_MIN;
+    }
+    ntp_cache[NTPCACHESIZE] = 0;
+}
+
+long long get_ntp_offset() {
+    return ntp_cache[NTPCACHESIZE];
+}
+
+static void update_ntp_cache(long long offset, long long arrival_time) {
+    // average the offsets, filter out outliers
+
+    int i, d, minindex, maxindex;
+    long long total;
+
+    for (i = 0; i < (NTPCACHESIZE - 1);  i++) {
+        ntp_cache[i] = ntp_cache[i+1];
+    }
+    ntp_cache[NTPCACHESIZE - 1] = offset;
+
+    d = 0;
+    minindex = 0;
+    maxindex = 0;
+    for (i = 0; i < NTPCACHESIZE; i++) {
+        if (ntp_cache[i] != LLONG_MIN) {
+            d++;
+            minindex = (ntp_cache[i] < ntp_cache[minindex] ? i : minindex);
+            maxindex = (ntp_cache[i] > ntp_cache[maxindex] ? i : maxindex);
+        }
+    }
+    debug(2, "ntp: valid entries: %d\n", d);
+    if (d < 5)
+        minindex = maxindex = -1;
+    d = 0;
+    total = 0;
+    for (i = 0; i < NTPCACHESIZE; i++) {
+        debug(3, "ntp[%d]: %lld, d: %d\n", i, ntp_cache[i] , d);
+        if ((ntp_cache[i] != LLONG_MIN) && (i != minindex) && (i != maxindex)) {
+            d++;
+            total += ntp_cache[i];
+        }
+    }
+    ntp_cache[NTPCACHESIZE] = total / d;
+    debug(2, "ntp: offset: %lld, d: %d\n", ntp_cache[NTPCACHESIZE], d);
+}
+
+static long long tspk_to_us(struct timespec tspk) {
+    long long usecs;
+
+    usecs = tspk.tv_sec * 1000000LL;
+
+    return usecs + (tspk.tv_nsec / 1000);
+}
+
+long long tstp_us() {
+    struct timespec tv;
+    get_current_time(&tv);
+    return tspk_to_us(tv);
+}
+
+static long long ntp_tsp_to_us(uint32_t timestamp_hi, uint32_t timestamp_lo) {
+    long long timetemp;
+
+    timetemp = (long long)timestamp_hi * 1000000LL;
+    timetemp += ((long long)timestamp_lo * 1000000LL) >> 32;
+
+    return timetemp;
+}
 
 static void *rtp_receiver(void *arg) {
     // we inherit the signal mask (SIGUSR1)
     uint8_t packet[2048], *pktp;
-
+    sync_cfg sync_tag, no_tag;
+    sync_cfg * pkt_tag;
+    int sync_fresh = 0;
     ssize_t nread;
+
+    no_tag.rtp_tsp = 0;
+    no_tag.ntp_tsp = 0;
+    no_tag.sync_mode = NOSYNC;
+
     while (1) {
         if (please_shutdown)
             break;
-        nread = recv(sock, packet, sizeof(packet), 0);
+        nread = recv(server_sock, packet, sizeof(packet), 0);
         if (nread < 0)
             break;
 
         ssize_t plen = nread;
         uint8_t type = packet[1] & ~0x80;
-        if (type == 0x54) // sync
+        if (type==0x54) {  // sync
+            if (plen != 20) {
+                warn("Sync packet with wrong length %d received\n", plen);
+                continue;
+            }
+
+            sync_tag.rtp_tsp = ntohl(*(uint32_t *)(packet+16));
+            debug(3, "Sync packet rtp_tsp %lu\n", sync_tag.rtp_tsp);
+            sync_tag.ntp_tsp = ntp_tsp_to_us(ntohl(*(uint32_t *)(packet+8)), ntohl(*(uint32_t *)(packet+12)));
+            debug(3, "Sync packet ntp_tsp %lld\n", sync_tag.ntp_tsp);
+            // check if extension bit is set; this will be the case for the first sync
+            sync_tag.sync_mode = ((packet[0] & 0x10) ? E_NTPSYNC : NTPSYNC);
+            sync_fresh = 1;
             continue;
+        }
         if (type == 0x60 || type == 0x56) {   // audio data / resend
             pktp = packet;
             if (type==0x56) {
                 pktp += 4;
                 plen -= 4;
             }
-            seq_t seqno = ntohs(*(unsigned short *)(pktp+2));
+
+            seq_t seqno = ntohs(*(uint16_t *)(pktp+2));
+            unsigned long rtp_tsp = ntohl(*(uint32_t *)(pktp+4));
 
             pktp += 12;
             plen -= 12;
 
             // check if packet contains enough content to be reasonable
             if (plen >= 16) {
-                player_put_packet(seqno, pktp, plen);
+                // strict -> find a rtp match, this might happen on resend packets, or,
+                // in weird network circumstances, even more than once.
+                // non-strickt -> just stick it to the first audio packet, _once_
+                if ((strict_rtp && (rtp_tsp == sync_tag.rtp_tsp))
+                        || (!strict_rtp && sync_fresh && (type == 0x60))) {
+                    debug(2, "Packet for with sync data was sent has arrived (%04X)\n", seqno);
+                    pkt_tag = &sync_tag;
+                    sync_fresh = 0;
+                } else
+                    pkt_tag = &no_tag;
+
+                player_put_packet(seqno, *pkt_tag, pktp, plen);
                 continue;
             }
             if (type == 0x56 && seqno == 0) {
@@ -86,12 +228,98 @@ static void *rtp_receiver(void *arg) {
     }
 
     debug(1, "RTP thread interrupted. terminating.\n");
-    close(sock);
 
     return NULL;
 }
 
-static int bind_port(SOCKADDR *remote) {
+static void *ntp_receiver(void *arg) {
+    // we inherit the signal mask (SIGUSR1)
+    uint8_t packet[2048];
+    struct timespec tv;
+
+    ssize_t nread;
+    while (1) {
+        if (please_shutdown)
+            break;
+        nread = recv(timing_sock, packet, sizeof(packet), 0);
+        if (nread < 0)
+            break;
+        get_current_time(&tv);
+
+        ssize_t plen = nread;
+        uint8_t type = packet[1] & ~0x80;
+        if (type == 0x53) {
+            if (plen != 32) {
+                warn("Timing packet with wrong length %d received\n", plen);
+                continue;
+            }
+            long long ntp_ref_tsp = ntp_tsp_to_us(ntohl(*(uint32_t *)(packet+8)), ntohl(*(uint32_t *)(packet+12)));
+            debug(2, "Timing packet ntp_ref_tsp %lld\n", ntp_ref_tsp);
+            long long ntp_rec_tsp = ntp_tsp_to_us(ntohl(*(uint32_t *)(packet+16)), ntohl(*(uint32_t *)(packet+20)));
+            debug(2, "Timing packet ntp_rec_tsp %lld\n", ntp_rec_tsp);
+            long long ntp_sen_tsp = ntp_tsp_to_us(ntohl(*(uint32_t *)(packet+24)), ntohl(*(uint32_t *)(packet+28)));
+            debug(2, "Timing packet ntp_sen_tsp %lld\n", ntp_sen_tsp);
+            long long ntp_loc_tsp = tspk_to_us(tv);
+            debug(2, "Timing packet ntp_loc_tsp %lld\n", ntp_loc_tsp);
+
+            // from the ntp spec:
+            //    d = (t4 - t1) - (t3 - t2)  and  c = (t2 - t1 + t3 - t4)/2
+            long long d = (ntp_loc_tsp - ntp_ref_tsp) - (ntp_sen_tsp - ntp_rec_tsp);
+            long long c = ((ntp_rec_tsp - ntp_ref_tsp) + (ntp_sen_tsp - ntp_loc_tsp)) / 2;
+
+            debug(2, "Round-trip delay %lld us\n", d);
+            debug(2, "Clock offset %lld us\n", c);
+            update_ntp_cache(c, ntp_loc_tsp);
+
+            continue;
+        }
+        warn("Unknown Timing packet of type 0x%02X length %d", type, nread);
+    }
+
+    debug(1, "Time receive thread interrupted. terminating.\n");
+
+    return NULL;
+}
+
+static void *ntp_sender(void *arg) {
+    // we inherit the signal mask (SIGUSR1)
+    int i = 0;
+    int cc;
+    struct timespec tv;
+    char req[32];
+    memset(req, 0, sizeof(req));
+
+    while (1) {
+        // at startup, we send more timing request to fill up the cache
+        if (please_shutdown)
+            break;
+
+        req[0] = 0x80;
+        req[1] = 0x52|0x80;  // Apple 'ntp request'
+        *(uint16_t *)(req+2) = htons(7);  // seq no, needs to be 7 or iTunes won't respond
+
+        get_current_time(&tv);
+        *(uint32_t *)(req+24) = htonl((uint32_t)tv.tv_sec);
+        *(uint32_t *)(req+28) = htonl((uint32_t)tv.tv_nsec * 0x100000000 / (1000 * 1000 * 1000));
+
+        cc = sendto(timing_sock, req, sizeof(req), 0, (struct sockaddr*)&rtp_timing, addrlen);
+        if (cc < 0){
+            die("send packet failed in send_timing_packet. error(%d)\n", errno);
+        }
+        debug(2, "Current time s:%lu us:%lu\n", (unsigned int) tv.tv_sec, (unsigned int) tv.tv_nsec / 1000);
+        // todo: randomize time at which to send timing packets to avoid timing floods at the client
+        if (i<2){
+            i++;
+            usleep(50000);
+        } else
+            sleep(3);
+    }
+
+    debug(1, "Time send thread interrupted. terminating.\n");
+
+    return NULL;
+}
+static struct addrinfo *get_address_info(SOCKADDR *remote) {
     struct addrinfo hints, *info;
 
     memset(&hints, 0, sizeof(hints));
@@ -104,10 +332,16 @@ static int bind_port(SOCKADDR *remote) {
     if (ret < 0)
         die("failed to get usable addrinfo?! %s", gai_strerror(ret));
 
-    sock = socket(remote->SAFAMILY, SOCK_DGRAM, IPPROTO_UDP);
-    ret = bind(sock, info->ai_addr, info->ai_addrlen);
+    return info;
+}
 
-    freeaddrinfo(info);
+static int bind_port(struct addrinfo *info, int *sock) {
+    int ret;
+
+    if (sock == NULL)
+        die("socket is NULL");
+    *sock = socket(info->ai_family, SOCK_DGRAM, IPPROTO_UDP);
+    ret = bind(*sock, info->ai_addr, info->ai_addrlen);
 
     if (ret < 0)
         die("could not bind a UDP port!");
@@ -115,7 +349,7 @@ static int bind_port(SOCKADDR *remote) {
     int sport;
     SOCKADDR local;
     socklen_t local_len = sizeof(local);
-    getsockname(sock, (struct sockaddr*)&local, &local_len);
+    getsockname(*sock, (struct sockaddr*)&local, &local_len);
 #ifdef AF_INET6
     if (local.SAFAMILY == AF_INET6) {
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6*)&local;
@@ -130,37 +364,53 @@ static int bind_port(SOCKADDR *remote) {
     return sport;
 }
 
+int rtp_setup(SOCKADDR *remote, int *cport, int *tport) {
+    // we take the client's cport and tport as input and overwrite them with our own
+    // we only create two sockets instead of three, combining control and data
+    // allows for one, simpler rtp receive thread
+    int server_port;
+    struct addrinfo *info;
 
-int rtp_setup(SOCKADDR *remote, int cport, int tport) {
     if (running)
         die("rtp_setup called with active stream!");
 
-    debug(1, "rtp_setup: cport=%d tport=%d\n", cport, tport);
-
-    // we do our own timing and ignore the timing port.
-    // an audio perfectionist may wish to learn the protocol.
-
     memcpy(&rtp_client, remote, sizeof(rtp_client));
+    memcpy(&rtp_timing, remote, sizeof(rtp_timing));
 #ifdef AF_INET6
     if (rtp_client.SAFAMILY == AF_INET6) {
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6*)&rtp_client;
-        sa6->sin6_port = htons(cport);
+        sa6->sin6_port = htons(*cport);
+        struct sockaddr_in6 *sa6_t = (struct sockaddr_in6*)&rtp_timing;
+        sa6_t->sin6_port = htons(*tport);
     } else
 #endif
     {
         struct sockaddr_in *sa = (struct sockaddr_in*)&rtp_client;
-        sa->sin_port = htons(cport);
+        sa->sin_port = htons(*cport);
+        struct sockaddr_in *sa_t = (struct sockaddr_in*)&rtp_timing;
+        sa_t->sin_port = htons(*tport);
     }
 
-    int sport = bind_port(remote);
+    // since we create sockets all alike the remote's, the address length
+    // is equal for all
+    info = get_address_info(remote);
+    addrlen = info->ai_addrlen;
 
-    debug(1, "rtp listening on port %d\n", sport);
+    *cport = bind_port(info, &server_sock);
+    server_port = *cport;
+    *tport = bind_port(info, &timing_sock);
+    freeaddrinfo(info);
+    debug(1, "Rtp listening on dataport %d, controlport %d. Timing port is %d.\n", server_port, *cport, *tport);
+
+    reset_ntp_cache();
 
     please_shutdown = 0;
     pthread_create(&rtp_thread, NULL, &rtp_receiver, NULL);
+    pthread_create(&ntp_receive_thread, NULL, &ntp_receiver, NULL);
+    pthread_create(&ntp_send_thread, NULL, &ntp_sender, NULL);
 
     running = 1;
-    return sport;
+    return server_port;
 }
 
 void rtp_shutdown(void) {
@@ -170,12 +420,19 @@ void rtp_shutdown(void) {
     debug(2, "shutting down RTP thread\n");
     please_shutdown = 1;
     pthread_kill(rtp_thread, SIGUSR1);
+    pthread_kill(ntp_receive_thread, SIGUSR1);
+    pthread_kill(ntp_send_thread, SIGUSR1);
     void *retval;
     pthread_join(rtp_thread, &retval);
+    pthread_join(ntp_receive_thread, &retval);
+    pthread_join(ntp_send_thread, &retval);
+    close(server_sock);
+    close(timing_sock);
     running = 0;
 }
 
 void rtp_request_resend(seq_t first, seq_t last) {
+    int cc;
     if (!running)
         die("rtp_request_resend called without active stream!");
 
@@ -189,5 +446,8 @@ void rtp_request_resend(seq_t first, seq_t last) {
     *(unsigned short *)(req+4) = htons(first);  // missed seqnum
     *(unsigned short *)(req+6) = htons(last-first+1);  // count
 
-    sendto(sock, req, sizeof(req), 0, (struct sockaddr*)&rtp_client, sizeof(rtp_client));
+    cc = sendto(server_sock, req, sizeof(req), 0, (struct sockaddr*)&rtp_client, addrlen);
+    if (cc < 0){
+        die("send packet failed in rtp_request_resend. error(%d)\n", errno);
+    }
 }

--- a/rtp.h
+++ b/rtp.h
@@ -7,7 +7,7 @@ int rtp_setup(SOCKADDR *remote, int *controlport, int *timingport);
 void rtp_record(int rtp_mode);
 void rtp_shutdown(void);
 void rtp_request_resend(seq_t first, seq_t last);
-long long get_ntp_offset();
+long long get_sync_time();
 long long tstp_us();
 
 #endif // _RTP_H

--- a/rtp.h
+++ b/rtp.h
@@ -3,8 +3,11 @@
 
 #include <sys/socket.h>
 
-int rtp_setup(SOCKADDR *remote, int controlport, int timingport);
+int rtp_setup(SOCKADDR *remote, int *controlport, int *timingport);
+void rtp_record(int rtp_mode);
 void rtp_shutdown(void);
 void rtp_request_resend(seq_t first, seq_t last);
+long long get_ntp_offset();
+long long tstp_us();
 
 #endif // _RTP_H

--- a/rtsp.c
+++ b/rtsp.c
@@ -407,7 +407,7 @@ static void handle_setup(rtsp_conn_info *conn,
     tport = atoi(p);
 
     rtsp_take_player();
-    int sport = rtp_setup(&conn->remote, cport, tport);
+    int sport = rtp_setup(&conn->remote, &cport, &tport);
     if (!sport)
         return;
 
@@ -416,7 +416,7 @@ static void handle_setup(rtsp_conn_info *conn,
     char resphdr[100];
     snprintf(resphdr, sizeof(resphdr),
              "RTP/AVP/UDP;unicast;mode=record;server_port=%d;control_port=%d;timing_port=%d",
-             sport, sport, sport);
+             sport, cport, tport);
     msg_add_header(resp, "Transport", resphdr);
 
     msg_add_header(resp, "Session", "1");

--- a/rtsp.c
+++ b/rtsp.c
@@ -886,8 +886,8 @@ respond:
     if (conn->fd > 0)
         close(conn->fd);
     if (rtsp_playing()) {
-        rtp_shutdown();
         player_stop();
+        rtp_shutdown();
         please_shutdown = 0;
         pthread_mutex_unlock(&playing_mutex);
     }

--- a/rtsp.c
+++ b/rtsp.c
@@ -380,10 +380,39 @@ static void handle_teardown(rtsp_conn_info *conn,
 
 static void handle_flush(rtsp_conn_info *conn,
                          rtsp_message *req, rtsp_message *resp) {
+    // the "RTP-Info" header tells us what the seqno and rtptime of the next
+    // audio packet will be, should playback resume
+    int seq;
+    unsigned long rtp_tsp;
+    unsigned long rtptime;
+
     if (!rtsp_playing())
         return;
-    player_flush();
+
+    char *hdr = msg_get_header(req, "RTP-Info");
+    if (!hdr)
+        return;
+    char *p;
+    p = strstr(hdr, "seq=");
+    if (!p)
+        return;
+    p = strchr(p, '=') + 1;
+    seq = atoi(p);
+    p = strstr(hdr, "rtptime=");
+    if (!p)
+        return;
+    p = strchr(p, '=') + 1;
+    rtptime = strtoul(p, NULL, 0);
+    debug(1, "Received seq: %04X, rtptime: %lu\n", seq, rtptime);
+
+    rtp_tsp = player_flush(seq, rtptime);
+    char *resphdr = malloc(32);
+    sprintf(resphdr, "rtptime=%lu", rtp_tsp);
+    debug(1, "Reporting RTP-Info: %s\n", resphdr);
+    msg_add_header(resp, "RTP-Info", resphdr);
     resp->respcode = 200;
+
+    free(resphdr);
 }
 
 static void handle_setup(rtsp_conn_info *conn,
@@ -422,6 +451,43 @@ static void handle_setup(rtsp_conn_info *conn,
     msg_add_header(resp, "Session", "1");
 
     resp->respcode = 200;
+}
+
+static void handle_record(rtsp_conn_info *conn,
+                         rtsp_message *req, rtsp_message *resp) {
+    // most clients will add a "RTP-Info" header, so we know the first
+    // audio packet's seqno and rtptime.
+    // if there's no "RTP-Info" header, we go into a loose RTP mode
+    int seq = -1;
+    unsigned long rtptime = 0;
+    int rtp_mode = 0;
+    char *hdr = msg_get_header(req, "RTP-Info");
+    if (hdr) {
+        char *p;
+        p = strstr(hdr, "seq=");
+        if (!p)
+            return;
+        p = strchr(p, '=') + 1;
+        seq = atoi(p);
+        p = strstr(hdr, "rtptime=");
+        if (!p)
+            return;
+        p = strchr(p, '=') + 1;
+        rtptime = strtoul(p, NULL, 0);
+        rtp_mode = 1;
+    }
+    debug(1, "Received seq: %04X, rtptime: %lu\n", seq, rtptime);
+    rtp_record(rtp_mode);
+    player_flush(seq, rtptime);
+
+    // note: it is assumed we're supposed to return the delay in ms
+    char *resphdr = malloc(10);
+    sprintf(resphdr, "%d", config.delay/1000);
+    debug(1, "Reporting %sms delay\n", resphdr);
+    msg_add_header(resp, "Audio-Latency", resphdr);
+    resp->respcode = 200;
+
+    free(resphdr);
 }
 
 static void handle_ignore(rtsp_conn_info *conn,
@@ -620,7 +686,7 @@ static struct method_handler {
     {"SETUP",           handle_setup},
     {"GET_PARAMETER",   handle_ignore},
     {"SET_PARAMETER",   handle_set_parameter},
-    {"RECORD",          handle_ignore},
+    {"RECORD",          handle_record},
     {NULL,              NULL}
 };
 

--- a/shairport.c
+++ b/shairport.c
@@ -93,8 +93,8 @@ void usage(char *progname) {
     printf("    -p, --port=PORT     set RTSP listening port\n");
     printf("    -a, --name=NAME     set advertised name\n");
     printf("    -k, --password=PW   require password to stream audio\n");
-    printf("    -b FILL             set how full the buffer must be before audio output\n");
-    printf("                        starts. This value is in frames; default %d\n", config.buffer_start_fill);
+    printf("    -t, --delay=TIME    set by how much audio is delayed.\n");
+    printf("                        This value is in ms; default %d\n", config.delay/1000);
     printf("    -d, --daemon        fork (daemonise). The PID of the child process is\n");
     printf("                        written to stdout, unless a pidfile is used.\n");
     printf("    -P, --pidfile=FILE  write daemon's pid to FILE on startup.\n");
@@ -138,12 +138,13 @@ int parse_options(int argc, char **argv) {
         {"wait-cmd",  no_argument,        NULL, 'w'},
         {"meta-dir",  required_argument,  NULL, 'M'},
         {"mdns",      required_argument,  NULL, 'm'},
+        {"delay",     required_argument,  NULL, 't'},
         {NULL,        0,                  NULL,   0}
     };
 
     int opt;
     while ((opt = getopt_long(argc, argv,
-                              "+hdvP:l:e:p:a:k:o:b:B:E:M:wm:",
+                              "+hdvP:l:e:p:a:k:o:t:B:E:M:wm:",
                               long_options, NULL)) > 0) {
         switch (opt) {
             default:
@@ -170,8 +171,8 @@ int parse_options(int argc, char **argv) {
             case 'k':
                 config.password = optarg;
                 break;
-            case 'b':
-                config.buffer_start_fill = atoi(optarg);
+            case 't':
+                config.delay = atoi(optarg) * 1000;
                 break;
             case 'B':
                 config.cmd_start = optarg;
@@ -278,7 +279,7 @@ int main(int argc, char **argv) {
     memset(&config, 0, sizeof(config));
 
     // set defaults
-    config.buffer_start_fill = 220;
+    config.delay = 2205000; //todo: check with an airport express what this should be
     config.port = 5002;
     char hostname[100];
     gethostname(hostname, 100);


### PR DESCRIPTION
This converts buffered playback to time synchronised playback.
-adds a ntpsender and a ntpreceiver thread to measure sender time offset
-tries to synchronise audio at the sync packets by adjusting the playback rate

The code is not quite ready for show time:
Regulation is twitchy
There are audible glitches maybe due to the above?
Time related function should probably be moved to timing.[ch]
What to do with sinks that do not provide delay information?

Anyway, I'd like some feedback from interested parties.
