### PR TITLE
Corrected daemon path according to makefile

### DIFF
--- a/scripts/debian/init.d/shairport
+++ b/scripts/debian/init.d/shairport
@@ -14,7 +14,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Shairport Airtunes emulator"
 NAME=shairport
-DAEMON=/usr/bin/shairport
+DAEMON=/usr/local/bin/shairport
 
 # Configuration defaults
 USER=shairport


### PR DESCRIPTION
Just /usr/bin/shairport -> /usr/local/bin/shairport.
Otherwise init.d script will always say that "shairport is not installed".
