### PR TITLE
proposed patch for bug #303

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -4,11 +4,14 @@
 typedef struct {
     void (*help)(void);
     char *name;
+    int is_initialized;
 
     // start of program
     int (*init)(int argc, char **argv);
     // at end of program
     void (*deinit)(void);
+    // after idle timeouts
+    void (*reinit)(void);
 
     void (*start)(int sample_rate);
     // block of samples

--- a/audio.h
+++ b/audio.h
@@ -11,7 +11,7 @@ typedef struct {
     // at end of program
     void (*deinit)(void);
     // after idle timeouts
-    void (*reinit)(void);
+    int (*reinit)(void);
 
     void (*start)(int sample_rate);
     // block of samples

--- a/audio_ao.c
+++ b/audio_ao.c
@@ -32,6 +32,7 @@
 #include "common.h"
 #include "audio.h"
 
+audio_output audio_ao;
 ao_device *dev = NULL;
 ao_option *ao_opts = NULL;
 ao_sample_format fmt;

--- a/audio_ao.c
+++ b/audio_ao.c
@@ -34,6 +34,7 @@
 
 ao_device *dev = NULL;
 ao_option *ao_opts = NULL;
+ao_sample_format fmt;
 int driver;
 
 static void help(void) {
@@ -86,11 +87,6 @@ static int init(int argc, char **argv) {
     if (optind < argc)
         die("Invalid audio argument: %s", argv[optind]);
 
-    return reinit();
-}
-
-static int reinit(void) {
-    ao_sample_format fmt;
     memset(&fmt, 0, sizeof(fmt));
 
     fmt.bits = 16;
@@ -98,6 +94,13 @@ static int reinit(void) {
     fmt.channels = 2;
     fmt.byte_format = AO_FMT_NATIVE;
 
+    dev = ao_open_live(driver, &fmt, ao_opts);
+    audio_ao.is_initialized = (dev ? 1 : 0);
+    return dev ? 0 : 1;    
+}
+
+static int reinit(void) {
+    ao_initialize();
     dev = ao_open_live(driver, &fmt, ao_opts);
     audio_ao.is_initialized = (dev ? 1 : 0);
     return dev ? 0 : 1;    
@@ -131,6 +134,7 @@ audio_output audio_ao = {
     .help = &help,
     .init = &init,
     .deinit = &deinit,
+    .reinit = &reinit,
     .start = &start,
     .stop = &stop,
     .play = &play,

--- a/common.h
+++ b/common.h
@@ -33,6 +33,7 @@ typedef struct {
     char *pidfile;
     char *logfile;
     char *errfile;
+    int idle_timeout;
 } shairport_cfg;
 
 extern int debuglev;

--- a/rtsp.c
+++ b/rtsp.c
@@ -849,7 +849,7 @@ void rtsp_listen_loop(void) {
         }
         if (acceptfd < 0) {   // timeout
             if (config.idle_timeout && nconns == 0) {
-                debug(2, "idle_timeout: shutting down audio.\n")
+                debug(2, "idle_timeout: shutting down audio.\n");
                 config.output->deinit();
             }
             else {

--- a/rtsp.c
+++ b/rtsp.c
@@ -848,9 +848,10 @@ void rtsp_listen_loop(void) {
             }
         }
         if (acceptfd < 0) {   // timeout
-            if (config.idle_timeout && nconns == 0) {
+            if (config.idle_timeout && config.output->is_initialized && nconns == 0) {
                 debug(2, "idle_timeout: shutting down audio.\n");
                 config.output->deinit();
+                continue;
             }
             else {
                 continue;

--- a/rtsp.c
+++ b/rtsp.c
@@ -107,6 +107,7 @@ static void track_thread(rtsp_conn_info *conn) {
 static void cleanup_threads(void) {
     void *retval;
     int i;
+    if (nconns <= 0) return; // early exit if no threads (clean up log output)
     debug(2, "culling threads.\n");
     for (i=0; i<nconns; ) {
         if (conns[i]->running == 0) {
@@ -846,8 +847,15 @@ void rtsp_listen_loop(void) {
                 break;
             }
         }
-        if (acceptfd < 0) // timeout
-            continue;
+        if (acceptfd < 0) {   // timeout
+            if (config.idle_timeout && nconns == 0) {
+                debug(2, "idle_timeout: shutting down audio.\n")
+                config.output->deinit();
+            }
+            else {
+                continue;
+            }
+        }
 
         rtsp_conn_info *conn = malloc(sizeof(rtsp_conn_info));
         memset(conn, 0, sizeof(rtsp_conn_info));
@@ -860,6 +868,7 @@ void rtsp_listen_loop(void) {
             free(conn);
         } else {
             pthread_t rtsp_conversation_thread;
+            if (!(config.output->is_initialized)) config.output->reinit();
             ret = pthread_create(&rtsp_conversation_thread, NULL, rtsp_conversation_thread_func, conn);
             if (ret)
                 die("Failed to create RTSP receiver thread!");

--- a/shairport.c
+++ b/shairport.c
@@ -92,6 +92,7 @@ void usage(char *progname) {
     printf("                        starts. This value is in frames; default %d\n", config.buffer_start_fill);
     printf("    -d, --daemon        fork (daemonise). The PID of the child process is\n");
     printf("                        written to stdout, unless a pidfile is used.\n");
+    printf("    -i, --idle-timeout  shutdown audio when idle\n");
     printf("    -P, --pidfile=FILE  write daemon's pid to FILE on startup.\n");
     printf("                        Has no effect if -d is not specified\n");
     printf("    -l, --log=FILE      redirect shairport's standard output to FILE\n");
@@ -120,6 +121,7 @@ int parse_options(int argc, char **argv) {
     static struct option long_options[] = {
         {"help",    no_argument,        NULL, 'h'},
         {"daemon",  no_argument,        NULL, 'd'},
+        {"idle-timeout", no_argument,   NULL, 'i'},
         {"pidfile", required_argument,  NULL, 'P'},
         {"log",     required_argument,  NULL, 'l'},
         {"error",   required_argument,  NULL, 'e'},
@@ -136,7 +138,7 @@ int parse_options(int argc, char **argv) {
 
     int opt;
     while ((opt = getopt_long(argc, argv,
-                              "+hdvP:l:e:p:a:k:o:b:B:E:wm:",
+                              "+hdivP:l:e:p:a:k:o:b:B:E:wm:",
                               long_options, NULL)) > 0) {
         switch (opt) {
             default:
@@ -145,6 +147,9 @@ int parse_options(int argc, char **argv) {
                 exit(1);
             case 'd':
                 config.daemonise = 1;
+                break;
+            case 'i':
+                config.idle_timeout = 1;
                 break;
             case 'v':
                 debuglev++;


### PR DESCRIPTION
Proposing a fix for bug #303, where libao audio goes silent on raspberry pi after a day (or maybe longer) of idle time.   This patch is admittedly incomplete, but I wanted your feedback on the approach before going any farther on it.  

The idea is to close audio when shairport goes idle, and open audio when there is new music to play.  To accomplish this I
- added a command line flag
- added a int (*reinit)(void) to the audio_output struct
- in audio_ao **only** (for now) I implemented the reinit() function
- in rtsp.c, added the logic to shutdown/restart audio after idle periods

I've been testing this as home for two weeks and it has resolved the bug for me.  If you are ok with this direction then what remains is implementing similar init/deinit/reinit logic for the other audio drivers.  
