### PR TITLE
Honour CC, CFLAGS and LDFLAGS in configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ -z "${CC}" ] && CC=gcc
+
 echo Configuring Shairport
 
 rm -f config.mk config.h
@@ -19,7 +21,7 @@ export_config()
 check_header()
 {
     echo "#include<$1>" > .header_test.c
-    if gcc -c .header_test.c > /dev/null 2>&1 /dev/null;  then
+    if ${CC} ${CFLAGS} ${LDFLAGS} -c .header_test.c > /dev/null 2>&1 /dev/null;  then
         echo "$1 found"
         if [ "$2" ]; then
             export_config $2


### PR DESCRIPTION
This fixes feature detection when compiling w/o gcc (ie cross compiling).
