### PR TITLE
tinysvcmdns: Only append .local suffix if missing.

### DIFF
--- a/mdns_tinysvcmdns.c
+++ b/mdns_tinysvcmdns.c
@@ -54,8 +54,12 @@ static int mdns_tinysvcmdns_register(char *apname, int port) {
     // according to POSIX, this may be truncated without a final NULL !
     hostname[99] = 0;
 
-    // will not work on iOS if the hostname doesn't end in .local
-    strcat(hostname, ".local");
+    // will not work if the hostname doesn't end in .local
+    char *hostend = hostname + strlen(hostname);
+    if (strcmp(hostend - 6, ".local") != 0)
+    {
+        strcat(hostname, ".local");
+    }
 
     if (getifaddrs(&ifalist) < 0)
     {


### PR DESCRIPTION
The .local suffix should only be added to the hostname if it is missing.
It is already present on OS X hosts.

The hostname is never visible by the user, so duplicating the suffix is
not a big issue, but is nevertheless incorrect.
