### PR TITLE
fix: lower base sample for interpolated sample could be out-of-bounds

### DIFF
--- a/player.c
+++ b/player.c
@@ -400,7 +400,7 @@ static int stuff_buffer(double playback_rate, short *inptr, short *outptr) {
 
     if (rand() < p_stuff * RAND_MAX) {
         stuff = playback_rate > 1.0 ? -1 : 1;
-        stuffsamp = rand() % (frame_size - 1);
+        stuffsamp = 1 + (rand() % (frame_size - 2));
     }
 
     pthread_mutex_lock(&vol_mutex);


### PR DESCRIPTION
part2 of the patch series created in my sntp branch but are not necessary to enable the time sync feature

<code>stuffsamp</code> could be 0, then the interpolation will use <code>inptr[-2]</code>
that's not a sample...
