### PR TITLE
fix: gcc might not be the default c compiler

### DIFF
--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "${CC}" ] && CC=gcc
+[ -z "${CC}" ] && CC=cc
 
 echo Configuring Shairport
 


### PR DESCRIPTION
part3 of the patch series created in my sntp branch but are not necessary to enable the time sync feature
- ran into this one on a BSD system which only has clang installed for c compiler
- cc will always point to the c compiler.
- also  since we build with cc, we should use cc while configuring too
