### PR TITLE
fix: only sleep if delay is positive

### DIFF
--- a/audio_dummy.c
+++ b/audio_dummy.c
@@ -59,9 +59,9 @@ static void play(short buf[], int samples) {
 
     samples_played += samples;
 
-    long long finishtime = starttime + samples_played * 1e6 / Fs;
-
-    usleep(finishtime - nowtime);
+    long long sleeptime = starttime + samples_played * 1e6 / Fs - nowtime;
+    if (sleeptime > 0)
+        usleep(sleeptime );
 }
 
 static void stop(void) {


### PR DESCRIPTION
part4 of the patch series created in my sntp branch but are not necessary to enable the time sync feature
- ran into this one on a BSD system
- at startup we could be calling play() slightly too late,  so sleep time could be negative, hanging shairport.

looks like timing is a bit different on BSD vs Linux
