### PR TITLE
fix: first shutdown player, otherwise this hangs shairport on OpenBSD

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -820,8 +820,8 @@ respond:
     if (conn->fd > 0)
         close(conn->fd);
     if (rtsp_playing()) {
-        rtp_shutdown();
         player_stop();
+        rtp_shutdown();
         please_shutdown = 0;
         pthread_mutex_unlock(&playing_mutex);
     }


### PR DESCRIPTION
part5 of the patch series created in my sntp branch but are not necessary to enable the time sync feature

For some reason, shutting down work fine on Linux.
Anyway seems logical threads are shutdown in the reverse order they are created.
