### PR TITLE
fix: on a FreeBSD machine, assume OpenSSL is there

### DIFF
--- a/configure
+++ b/configure
@@ -59,7 +59,15 @@ do_pkg_config()
     fi
 }
 
-do_pkg_config OpenSSL       openssl
+# On FreeBSD, OpenSSL is always there, but no .pc file is installed,
+# so pkg-config does not report it
+if [ `uname` = 'FreeBSD' ]; then
+   echo "FreeBSD machine, assuming OpenSSL is there"
+   LDFLAGS="${LDFLAGS} -lssl -lcrypto"
+else
+   do_pkg_config OpenSSL       openssl
+fi
+
 do_pkg_config libao         ao              CONFIG_AO
 do_pkg_config PulseAudio    libpulse-simple CONFIG_PULSE
 do_pkg_config ALSA          alsa            CONFIG_ALSA


### PR DESCRIPTION
part6 of the patch series created in my sntp branch but are not necessary to enable the time sync feature

On FreeBSD, OpenSSL is always there, but no .pc file is installed,
so pkg-config does not report it, and <code>./configure</code> fails.
