### PR TITLE
Ensure that lograte sets log owner properly

### DIFF
--- a/scripts/debian/logrotate.d/shairport
+++ b/scripts/debian/logrotate.d/shairport
@@ -7,7 +7,7 @@
 	compress
 	delaycompress
 	notifempty
-	create 0660 root nogroup
+	create 0660 root audio
 	sharedscripts
 
 	postrotate


### PR DESCRIPTION
I found that, upon log rotation, shairport would fail to reload with the following:

```
FATAL: Could not open logfile
```

Logrotate was setting ownership of the logs to "root:nobody", when it should have been "root:audio". This pull request fixes that issue.
