### PR TITLE
Tell logrotate to copy permissions/owners

### DIFF
--- a/scripts/debian/logrotate.d/shairport
+++ b/scripts/debian/logrotate.d/shairport
@@ -7,7 +7,7 @@
 	compress
 	delaycompress
 	notifempty
-	create 0660 root nogroup
+	create
 	sharedscripts
 
 	postrotate


### PR DESCRIPTION
Improvement over #365
- By specifying no parameters to the 'create' command, we are asking
  logrotate to create the new log files with with the same permissions
  and ownership of the original file.
