### PR TITLE
Add install Net::SDP

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,7 @@ Perl modules (install from CPAN if needed e.g. `perl -MCPAN -e 'install X'`):
 
   * install XCode
   * install [Homebrew](https://github.com/mxcl/homebrew) or [MacPorts](http://www.macports.org/)
+  * install [Net::SDP](https://github.com/njh/perl-net-sdp)
   * type:
 
         $ export ARCHFLAGS="-arch x86_64" # (replace x86_64 by your arch)


### PR DESCRIPTION
Without installing, users receive the following error:

```
Can't locate Net/SDP.pm in @INC (you may need to install the Net::SDP
module) (@INC contains: /Library/Perl/5.18/darwin-thread-multi-2level
/Library/Perl/5.18 /Network/Library/Perl/5.18/darwin-thread-multi-2level
/Network/Library/Perl/5.18 /Library/Perl/Updates/5.18.2
/System/Library/Perl/5.18/darwin-thread-multi-2level
/System/Library/Perl/5.18
/System/Library/Perl/Extras/5.18/darwin-thread-multi-2level
/System/Library/Perl/Extras/5.18 .) at shairport.pl line 48.
BEGIN failed--compilation aborted at shairport.pl line 48.
```
